### PR TITLE
fix: Remove @Builder within the BaseException class

### DIFF
--- a/src/main/java/api/buyhood/global/common/exception/BaseException.java
+++ b/src/main/java/api/buyhood/global/common/exception/BaseException.java
@@ -1,15 +1,13 @@
 package api.buyhood.global.common.exception;
 
 import api.buyhood.global.common.exception.enums.ErrorCode;
-import lombok.Builder;
 import lombok.Getter;
 
 @Getter
 public abstract class BaseException extends RuntimeException {
 
 	private final ErrorCode errorCode;
-
-	@Builder
+	
 	protected BaseException(ErrorCode errorCode) {
 		this.errorCode = errorCode;
 	}


### PR DESCRIPTION
## 📌 PR 요약

- 추상 클래스인 BaseException 내 생성자에 선언한 `@Builder` 제거

## 🔗 관련 이슈

- 관련된 이슈 번호를 연결해주세요. (예: `closed #999`, `ref #999`)

## 🛠️ 작업 내역

- 추상 클래스인 BaseException 내 생성자에 선언한 `@Builder` 제거

## 📸 스크린샷 (선택)

작업 결과를 스크린샷으로 첨부해주세요.

| 기능  | 스크린샷               |
|-----|--------------------|
| 애플리케이션 실행 로그 | ![image](https://github.com/user-attachments/assets/62490662-1b97-4fd5-b7ce-9475fe5b7f1f) |

## ⚠️ 주의 사항 (선택)

리뷰어가 알아야 할 중요한 사항이나 주의할 점을 작성해주세요.

## ✅ 체크리스트

PR 작성자가 확인해야 할 항목입니다:

- [x] 코드가 정상적으로 동작하는지 확인했습니다.
- [x] 코드 리뷰어를 등록했습니다.
- [x] Labels를 등록했습니다.