### PR TITLE
fix: Modifying Access Restrictors on Constructors in Exception Classes

### DIFF
--- a/src/main/java/api/buyhood/global/common/exception/InvalidRequestException.java
+++ b/src/main/java/api/buyhood/global/common/exception/InvalidRequestException.java
@@ -4,7 +4,7 @@ import api.buyhood.global.common.exception.enums.ErrorCode;
 
 public class InvalidRequestException extends BaseException {
 
-	protected InvalidRequestException(ErrorCode errorCode) {
+	public InvalidRequestException(ErrorCode errorCode) {
 		super(errorCode);
 	}
 }

--- a/src/main/java/api/buyhood/global/common/exception/NotFoundException.java
+++ b/src/main/java/api/buyhood/global/common/exception/NotFoundException.java
@@ -4,7 +4,7 @@ import api.buyhood.global.common.exception.enums.ErrorCode;
 
 public class NotFoundException extends BaseException {
 
-	protected NotFoundException(ErrorCode errorCode) {
+	public NotFoundException(ErrorCode errorCode) {
 		super(errorCode);
 	}
 }

--- a/src/main/java/api/buyhood/global/common/exception/UnAuthorizedException.java
+++ b/src/main/java/api/buyhood/global/common/exception/UnAuthorizedException.java
@@ -4,7 +4,7 @@ import api.buyhood.global.common.exception.enums.ErrorCode;
 
 public class UnAuthorizedException extends BaseException {
 
-	protected UnAuthorizedException(ErrorCode errorCode) {
+	public UnAuthorizedException(ErrorCode errorCode) {
 		super(errorCode);
 	}
 }


### PR DESCRIPTION
## 📌 PR 요약

- Exception 클래스 내 생성자의 접근 제한자 레벨 변경

## 🔗 관련 이슈

- 관련된 이슈 번호를 연결해주세요. (예: `closed #999`, `ref #999`)

## 🛠️ 작업 내역

- Exception 클래스 내 생성자의 접근 제한자 레벨 변경
   - protected -> public

## 📸 스크린샷 (선택)

작업 결과를 스크린샷으로 첨부해주세요.

| 기능  | 스크린샷               |
|-----|--------------------|
| ProductService | ![image](https://github.com/user-attachments/assets/6cfe552f-680e-43bf-af15-297bdca440c7) |
| ProductErrorCode | ![image](https://github.com/user-attachments/assets/42d150e9-e91d-4a2b-9b44-f63eca8bb5b3) |
| InvalidRequestException | ![image](https://github.com/user-attachments/assets/322106b8-b311-4aac-8711-c8e13a0c66cd) |

## ⚠️ 주의 사항 (선택)

리뷰어가 알아야 할 중요한 사항이나 주의할 점을 작성해주세요.

## ✅ 체크리스트

PR 작성자가 확인해야 할 항목입니다:

- [x] 코드가 정상적으로 동작하는지 확인했습니다.
- [x] 코드 리뷰어를 등록했습니다.
- [x] Labels를 등록했습니다.