### PR TITLE
feat: Implementing category creation code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ out/
 
 ### VS Code ###
 .vscode/
+
+### properties ###
+*local.properties

--- a/src/main/java/api/buyhood/domain/product/controller/CategoryController.java
+++ b/src/main/java/api/buyhood/domain/product/controller/CategoryController.java
@@ -1,0 +1,27 @@
+package api.buyhood.domain.product.controller;
+
+import api.buyhood.domain.product.dto.request.CreateCategoryReq;
+import api.buyhood.domain.product.dto.response.CreateCategoryRes;
+import api.buyhood.domain.product.service.CategoryService;
+import api.buyhood.global.common.dto.Response;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class CategoryController {
+
+	private final CategoryService productService;
+
+	@PostMapping("/v1/categories")
+	public Response<CreateCategoryRes> createCategories(@Valid @RequestBody CreateCategoryReq request) {
+		CreateCategoryRes response = productService.createCategory(request.getCategoryName(), request.getParentId());
+		return Response.ok(response);
+	}
+
+}

--- a/src/main/java/api/buyhood/domain/product/dto/request/CreateCategoryReq.java
+++ b/src/main/java/api/buyhood/domain/product/dto/request/CreateCategoryReq.java
@@ -1,0 +1,17 @@
+package api.buyhood.domain.product.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class CreateCategoryReq {
+
+	@NotBlank(message = "카테고리 이름은 공백일 수 없습니다.")
+	@Size(min = 1, max = 30, message = "카테고리는 최소 1글자, 최대 30글자여야 합니다.")
+	private final String categoryName;
+
+	private final int parentId;
+}

--- a/src/main/java/api/buyhood/domain/product/dto/response/CreateCategoryRes.java
+++ b/src/main/java/api/buyhood/domain/product/dto/response/CreateCategoryRes.java
@@ -1,0 +1,24 @@
+package api.buyhood.domain.product.dto.response;
+
+import api.buyhood.domain.product.entity.Category;
+import lombok.Getter;
+
+@Getter
+public class CreateCategoryRes {
+
+	private final String parentName;
+	private final String categoryName;
+
+	private CreateCategoryRes(String parentName, String categoryName) {
+		this.parentName = parentName;
+		this.categoryName = categoryName;
+	}
+
+	public static CreateCategoryRes of(Category category) {
+		return new CreateCategoryRes(
+			category.getParent() == null
+				? "root" : category.getParent().getName(),
+			category.getName()
+		);
+	}
+}

--- a/src/main/java/api/buyhood/domain/product/repository/CategoryRepository.java
+++ b/src/main/java/api/buyhood/domain/product/repository/CategoryRepository.java
@@ -2,7 +2,17 @@ package api.buyhood.domain.product.repository;
 
 import api.buyhood.domain.product.entity.Category;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface CategoryRepository extends JpaRepository<Category, Long> {
+
+	@Query(
+		"select count(*) > 0 "
+			+ "from Category c "
+			+ "where c.name = :categoryName "
+			+ "and ((:parentId = 0 and c.parent is null) "
+			+ "or (c.parent.id = :parentId))")
+	boolean existsByParentIdAndName(@Param("categoryName") String categoryName, @Param("parentId") Long parentId);
 
 }

--- a/src/main/java/api/buyhood/domain/product/service/CategoryService.java
+++ b/src/main/java/api/buyhood/domain/product/service/CategoryService.java
@@ -1,0 +1,38 @@
+package api.buyhood.domain.product.service;
+
+import api.buyhood.domain.product.dto.response.CreateCategoryRes;
+import api.buyhood.domain.product.entity.Category;
+import api.buyhood.domain.product.repository.CategoryRepository;
+import api.buyhood.global.common.exception.InvalidRequestException;
+import api.buyhood.global.common.exception.enums.CategoryErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class CategoryService {
+
+	private final CategoryRepository categoryRepository;
+
+	@Transactional
+	public CreateCategoryRes createCategory(String categoryName, long parentId) {
+		if (categoryRepository.existsByParentIdAndName(categoryName, parentId)) {
+			throw new InvalidRequestException(CategoryErrorCode.DUPLICATE_CATEGORIES);
+		}
+
+		Category parent = categoryRepository.findById(parentId)
+			.orElse(null);
+
+		Category category = Category.builder()
+			.name(categoryName)
+			.parent(parent)
+			.build();
+
+		if (parent != null) {
+			parent.addChildCategory(category);
+		}
+
+		return CreateCategoryRes.of(categoryRepository.save(category));
+	}
+}

--- a/src/main/java/api/buyhood/global/common/exception/enums/CategoryErrorCode.java
+++ b/src/main/java/api/buyhood/global/common/exception/enums/CategoryErrorCode.java
@@ -1,0 +1,15 @@
+package api.buyhood.global.common.exception.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum CategoryErrorCode implements ErrorCode {
+
+	DUPLICATE_CATEGORIES(1400, "중복된 카테고리 입니다.", "");
+
+	private final int code;
+	private final String message;
+	private final String detail;
+}


### PR DESCRIPTION
## 📌 PR 요약

- 카테고리 생성 API 구현

## 🔗 관련 이슈

- 관련된 이슈 번호를 연결해주세요. (예: `closed #999`, `ref #999`)

## 🛠️ 작업 내역

- 카테고리 생성 API 구현

## 📸 스크린샷 (선택)

작업 결과를 스크린샷으로 첨부해주세요.

| 기능  | 스크린샷               |
|-----|--------------------|
| 최상위 카테고리 생성 | ![스크린샷 2025-05-26 225455](https://github.com/user-attachments/assets/251c1823-756b-4cbf-99c6-25b65241af96) |
| 일반 카테고리 생성 | ![스크린샷 2025-05-26 225515](https://github.com/user-attachments/assets/7185714b-ac90-49c7-bae9-2c002baafb7d) |
| 카테고리 중복 | ![스크린샷 2025-05-26 223432](https://github.com/user-attachments/assets/c62002df-7044-49b6-84be-420d32cf09c6) |

## ⚠️ 주의 사항 (선택)

- 카테고리 depth를 몇 단계까지 둘 것인지?
- 중복의 경우 특정 부모 카테고리 내에서 이름이 중복될 경우 예외 처리되도록 구현함
   - 중복 시 예외가 발생하는 것까진 확인했으나 handler 미구현으로 인해 제대로 확인 못함
- `categoryName`: 1 ~ 30자 사이, 공백 불가
- `parentId`: 공백 가능, 공백 시 최상위 카테고리로 생성됨

## ✅ 체크리스트

PR 작성자가 확인해야 할 항목입니다:

- [x] 코드가 정상적으로 동작하는지 확인했습니다.
- [x] 코드 리뷰어를 등록했습니다.
- [x] Labels를 등록했습니다.