### PR TITLE
fix(MFLP-16): Modify category creation service logic

### DIFF
--- a/src/main/java/api/buyhood/domain/product/dto/request/CreateCategoryReq.java
+++ b/src/main/java/api/buyhood/domain/product/dto/request/CreateCategoryReq.java
@@ -13,5 +13,5 @@ public class CreateCategoryReq {
 	@Size(min = 1, max = 30, message = "카테고리는 최소 1글자, 최대 30글자여야 합니다.")
 	private final String categoryName;
 
-	private final int parentId;
+	private final Long parentId;
 }

--- a/src/main/java/api/buyhood/domain/product/service/CategoryService.java
+++ b/src/main/java/api/buyhood/domain/product/service/CategoryService.java
@@ -23,22 +23,28 @@ public class CategoryService {
 	private final CategoryRepository categoryRepository;
 
 	@Transactional
-	public CreateCategoryRes createCategory(String categoryName, long parentId) {
+	public CreateCategoryRes createCategory(String categoryName, Long parentId) {
+		Category parent = null;
+		if (parentId != null && parentId != 0) {
+			parent = categoryRepository.findById(parentId)
+				.orElseThrow(() -> new NotFoundException(CategoryErrorCode.CATEGORY_NOT_FOUND));
+		}
+
 		if (categoryRepository.existsByParentIdAndName(categoryName, parentId)) {
 			throw new InvalidRequestException(CategoryErrorCode.DUPLICATE_CATEGORIES);
 		}
 
-		Category parent = categoryRepository.findById(parentId)
-			.orElse(null);
+		int depth = parent == null ? 0 : parent.getDepth() + 1;
+
+		if (depth >= 3) {
+			throw new InvalidRequestException(CategoryErrorCode.MAX_DEPTH_OVER);
+		}
 
 		Category category = Category.builder()
+			.depth(depth)
 			.name(categoryName)
 			.parent(parent)
 			.build();
-
-		if (parent != null) {
-			parent.addChildCategory(category);
-		}
 
 		return CreateCategoryRes.of(categoryRepository.save(category));
 	}


### PR DESCRIPTION
## 📌 PR 요약

- 카테고리 생성 서비스 로직 수정

## 🔗 관련 이슈

- MFLP-16

## 🛠️ 작업 내역

- 예외 처리 로직 추가
- parentId에 해당하는 카테고리가 없으면 자동으로 root로 생성되던 오류 수정

## 📸 스크린샷 (선택)

작업 결과를 스크린샷으로 첨부해주세요.

| 기능  | 스크린샷               |
|-----|--------------------|
| parentId가 0 또는 null일 경우 | ![스크린샷 2025-05-28 115526](https://github.com/user-attachments/assets/a4b26b3f-8dc1-4e04-8881-21bcbc78b955) |
| parentId를 찾을 수 없을 때 | ![image](https://github.com/user-attachments/assets/a1629f09-a8d2-4ff0-b159-5e18871676a3) |

## ⚠️ 주의 사항 (선택)

리뷰어가 알아야 할 중요한 사항이나 주의할 점을 작성해주세요.

## ✅ 체크리스트

PR 작성자가 확인해야 할 항목입니다:

- [x] 코드가 정상적으로 동작하는지 확인했습니다.
- [x] 코드 리뷰어를 등록했습니다.
- [x] Labels를 등록했습니다.