### PR TITLE
feat(mflp-21): Implenmenting getUser & getAllUsers

### DIFF
--- a/src/main/java/api/buyhood/domain/auth/controller/AuthController.java
+++ b/src/main/java/api/buyhood/domain/auth/controller/AuthController.java
@@ -3,10 +3,10 @@ package api.buyhood.domain.auth.controller;
 import api.buyhood.domain.auth.dto.req.SignupUserReq;
 import api.buyhood.domain.auth.dto.res.SignupUserRes;
 import api.buyhood.domain.auth.service.AuthService;
+import api.buyhood.global.common.dto.Response;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -21,17 +21,16 @@ public class AuthController {
 	private final AuthService authService;
 
 	@PostMapping("/v1/auth/signup")
-	public ResponseEntity<SignupUserRes> signup(
-		@Valid @RequestBody SignupUserReq signupUserReq
+	public ResponseEntity<Response<SignupUserRes>> signup(
+		@Valid @RequestBody SignupUserReq signupUserReq,
+		HttpHeaders headers
 	) {
 		SignupUserRes signupUserRes = authService.signUpUser(signupUserReq);
 
 		String accessToken = signupUserRes.getToken();
 
-		HttpHeaders headers = new HttpHeaders();
 		headers.add("Authorization", "Bearer " + accessToken);
 
-		return new ResponseEntity<>(signupUserRes, headers, HttpStatus.CREATED);
-
+		return ResponseEntity.ok().headers(headers).body(Response.ok(signupUserRes));
 	}
 }

--- a/src/main/java/api/buyhood/domain/auth/controller/AuthController.java
+++ b/src/main/java/api/buyhood/domain/auth/controller/AuthController.java
@@ -1,0 +1,36 @@
+package api.buyhood.domain.auth.controller;
+
+import api.buyhood.domain.auth.dto.req.SignupUserReq;
+import api.buyhood.domain.auth.dto.res.SignupUserRes;
+import api.buyhood.domain.auth.service.AuthService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class AuthController {
+
+	private final AuthService authService;
+
+	@PostMapping("/v1/auth/signup")
+	public ResponseEntity<SignupUserRes> signup(
+		@Valid @RequestBody SignupUserReq signupUserReq
+	) {
+		SignupUserRes signupUserRes = authService.signUpUser(signupUserReq);
+
+		String accessToken = signupUserRes.getToken();
+
+		HttpHeaders headers = new HttpHeaders();
+		headers.add("Authorization", "Bearer " + accessToken);
+
+		return new ResponseEntity<>(signupUserRes, headers, HttpStatus.CREATED);
+	}
+}

--- a/src/main/java/api/buyhood/domain/auth/controller/AuthController.java
+++ b/src/main/java/api/buyhood/domain/auth/controller/AuthController.java
@@ -32,5 +32,6 @@ public class AuthController {
 		headers.add("Authorization", "Bearer " + accessToken);
 
 		return new ResponseEntity<>(signupUserRes, headers, HttpStatus.CREATED);
+
 	}
 }

--- a/src/main/java/api/buyhood/domain/auth/dto/req/SigninUserReq.java
+++ b/src/main/java/api/buyhood/domain/auth/dto/req/SigninUserReq.java
@@ -1,0 +1,5 @@
+package api.buyhood.domain.auth.dto.req;
+
+public class SigninUserReq {
+
+}

--- a/src/main/java/api/buyhood/domain/auth/dto/req/SignupUserReq.java
+++ b/src/main/java/api/buyhood/domain/auth/dto/req/SignupUserReq.java
@@ -1,6 +1,5 @@
 package api.buyhood.domain.auth.dto.req;
 
-import api.buyhood.domain.user.enums.UserRole;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
@@ -17,8 +16,9 @@ public class SignupUserReq {
 	private String email;
 	@NotBlank
 	private String password;
+	@NotBlank
 	private String username;
+	@NotBlank
 	private String address;
-	private UserRole role;
 
 }

--- a/src/main/java/api/buyhood/domain/auth/dto/req/SignupUserReq.java
+++ b/src/main/java/api/buyhood/domain/auth/dto/req/SignupUserReq.java
@@ -1,0 +1,24 @@
+package api.buyhood.domain.auth.dto.req;
+
+import api.buyhood.domain.user.enums.UserRole;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class SignupUserReq {
+
+	@NotBlank
+	@Email
+	private String email;
+	@NotBlank
+	private String password;
+	private String username;
+	private String address;
+	private UserRole role;
+
+}

--- a/src/main/java/api/buyhood/domain/auth/dto/res/SignupUserRes.java
+++ b/src/main/java/api/buyhood/domain/auth/dto/res/SignupUserRes.java
@@ -1,0 +1,13 @@
+package api.buyhood.domain.auth.dto.res;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+
+@Getter
+@RequiredArgsConstructor
+public class SignupUserRes {
+
+	private final String token;
+
+}

--- a/src/main/java/api/buyhood/domain/auth/entity/AuthUser.java
+++ b/src/main/java/api/buyhood/domain/auth/entity/AuthUser.java
@@ -1,0 +1,22 @@
+package api.buyhood.domain.auth.entity;
+
+import api.buyhood.domain.user.enums.UserRole;
+import java.util.Collection;
+import java.util.List;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+
+@Getter
+public class AuthUser {
+
+	private final Long id;
+	private final String email;
+	private final Collection<? extends GrantedAuthority> authorities;
+
+	public AuthUser(Long id, String email, UserRole role) {
+		this.id = id;
+		this.email = email;
+		this.authorities = List.of(new SimpleGrantedAuthority(role.name()));
+	}
+}

--- a/src/main/java/api/buyhood/domain/auth/service/AuthService.java
+++ b/src/main/java/api/buyhood/domain/auth/service/AuthService.java
@@ -1,0 +1,56 @@
+package api.buyhood.domain.auth.service;
+
+import api.buyhood.domain.auth.dto.req.SignupUserReq;
+import api.buyhood.domain.auth.dto.res.SignupUserRes;
+import api.buyhood.domain.seller.repository.SellerRepository;
+import api.buyhood.domain.user.entity.User;
+import api.buyhood.domain.user.enums.UserRole;
+import api.buyhood.domain.user.repository.UserRepository;
+import api.buyhood.global.common.exception.ConflictException;
+import api.buyhood.global.common.exception.enums.AuthErrorCode;
+import api.buyhood.global.common.util.JwtUtil;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+	private final UserRepository userRepository;
+	private final SellerRepository sellerRepository;
+	private final PasswordEncoder passwordEncoder;
+	private final JwtUtil jwtUtil;
+
+	@Transactional
+	public SignupUserRes signUpUser(
+		@Valid SignupUserReq signupUserReq
+	) {
+		if (userRepository.existsByEmail(signupUserReq.getEmail())) {
+			throw new ConflictException(AuthErrorCode.EMAIL_DUPLICATED);
+		}
+
+		String password = passwordEncoder.encode(signupUserReq.getPassword());
+		UserRole userRole = UserRole.USER;
+
+		User newUser = User.builder()
+			.email(signupUserReq.getEmail())
+			.password(password)
+			.role(userRole)
+			.address(signupUserReq.getAddress())
+			.username(signupUserReq.getUsername())
+			.build();
+
+		User savedUser = userRepository.save(newUser);
+
+		String accessToken = jwtUtil.createToken(
+			savedUser.getId(),
+			savedUser.getUsername(),
+			savedUser.getEmail(),
+			savedUser.getRole());
+
+		return new SignupUserRes(accessToken);
+	}
+}

--- a/src/main/java/api/buyhood/domain/auth/service/AuthService.java
+++ b/src/main/java/api/buyhood/domain/auth/service/AuthService.java
@@ -4,12 +4,10 @@ import api.buyhood.domain.auth.dto.req.SignupUserReq;
 import api.buyhood.domain.auth.dto.res.SignupUserRes;
 import api.buyhood.domain.seller.repository.SellerRepository;
 import api.buyhood.domain.user.entity.User;
-import api.buyhood.domain.user.enums.UserRole;
 import api.buyhood.domain.user.repository.UserRepository;
 import api.buyhood.global.common.exception.ConflictException;
 import api.buyhood.global.common.exception.enums.AuthErrorCode;
 import api.buyhood.global.common.util.JwtUtil;
-import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -26,19 +24,17 @@ public class AuthService {
 
 	@Transactional
 	public SignupUserRes signUpUser(
-		@Valid SignupUserReq signupUserReq
+		SignupUserReq signupUserReq
 	) {
 		if (userRepository.existsByEmail(signupUserReq.getEmail())) {
 			throw new ConflictException(AuthErrorCode.EMAIL_DUPLICATED);
 		}
 
-		String password = passwordEncoder.encode(signupUserReq.getPassword());
-		UserRole userRole = UserRole.USER;
+		String encodedPassword = passwordEncoder.encode(signupUserReq.getPassword());
 
 		User newUser = User.builder()
 			.email(signupUserReq.getEmail())
-			.password(password)
-			.role(userRole)
+			.password(encodedPassword)
 			.address(signupUserReq.getAddress())
 			.username(signupUserReq.getUsername())
 			.build();
@@ -46,7 +42,6 @@ public class AuthService {
 		User savedUser = userRepository.save(newUser);
 
 		String accessToken = jwtUtil.createToken(
-			savedUser.getId(),
 			savedUser.getUsername(),
 			savedUser.getEmail(),
 			savedUser.getRole());

--- a/src/main/java/api/buyhood/domain/seller/service/SellerService.java
+++ b/src/main/java/api/buyhood/domain/seller/service/SellerService.java
@@ -1,0 +1,8 @@
+package api.buyhood.domain.seller.service;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class SellerService {
+
+}

--- a/src/main/java/api/buyhood/domain/user/controller/UserController.java
+++ b/src/main/java/api/buyhood/domain/user/controller/UserController.java
@@ -1,0 +1,15 @@
+package api.buyhood.domain.user.controller;
+
+import api.buyhood.domain.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class UserController {
+
+	private final UserService userService;
+
+}

--- a/src/main/java/api/buyhood/domain/user/controller/UserController.java
+++ b/src/main/java/api/buyhood/domain/user/controller/UserController.java
@@ -1,8 +1,15 @@
 package api.buyhood.domain.user.controller;
 
+import api.buyhood.domain.user.dto.res.GetUserRes;
 import api.buyhood.domain.user.service.UserService;
+import api.buyhood.global.common.dto.Response;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -12,4 +19,19 @@ public class UserController {
 
 	private final UserService userService;
 
+	@GetMapping("/v1/users/{userId}")
+	public Response<GetUserRes> getUser(@PathVariable @Valid Long userId) {
+		GetUserRes getUserRes = userService.getUser(userId);
+
+		return Response.ok(getUserRes);
+	}
+
+	@GetMapping("v1/users")
+	public Response<Page<GetUserRes>> getUsers(
+		@RequestParam(defaultValue = "0") int page,
+		@RequestParam(defaultValue = "10") int size) {
+		Page<GetUserRes> getUserRes = userService.getAllUsers(page, size);
+		
+		return Response.ok(getUserRes);
+	}
 }

--- a/src/main/java/api/buyhood/domain/user/dto/res/GetUserRes.java
+++ b/src/main/java/api/buyhood/domain/user/dto/res/GetUserRes.java
@@ -1,0 +1,26 @@
+package api.buyhood.domain.user.dto.res;
+
+import api.buyhood.domain.user.entity.User;
+import api.buyhood.domain.user.enums.UserRole;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class GetUserRes {
+
+	private final String username;
+	private final String email;
+	//TODO:역할이 여러개일 경우 리스트에 담아서 내야할까?
+	private final UserRole role;
+	private final String address;
+
+	public static GetUserRes of(User user) {
+		return new GetUserRes(
+			user.getUsername(),
+			user.getEmail(),
+			user.getRole(),
+			user.getAddress()
+		);
+	}
+}

--- a/src/main/java/api/buyhood/domain/user/entity/User.java
+++ b/src/main/java/api/buyhood/domain/user/entity/User.java
@@ -35,7 +35,7 @@ public class User extends BaseTimeEntity {
 	@Column(nullable = false)
 	private String password;
 
-	@Column(nullable = false)
+	@Column
 	@Enumerated(EnumType.STRING)
 	private UserRole role;
 

--- a/src/main/java/api/buyhood/domain/user/entity/User.java
+++ b/src/main/java/api/buyhood/domain/user/entity/User.java
@@ -35,7 +35,7 @@ public class User extends BaseTimeEntity {
 	@Column(nullable = false)
 	private String password;
 
-	@Column
+	@Column(nullable = false)
 	@Enumerated(EnumType.STRING)
 	private UserRole role;
 
@@ -43,11 +43,11 @@ public class User extends BaseTimeEntity {
 	private String address;
 
 	@Builder
-	public User(String username, String email, String password, UserRole role, String address) {
+	public User(String username, String email, String password, String address) {
 		this.username = username;
 		this.email = email;
 		this.password = password;
-		this.role = role;
+		this.role = UserRole.USER;
 		this.address = address;
 	}
 }

--- a/src/main/java/api/buyhood/domain/user/enums/UserRole.java
+++ b/src/main/java/api/buyhood/domain/user/enums/UserRole.java
@@ -1,5 +1,7 @@
 package api.buyhood.domain.user.enums;
 
+import api.buyhood.global.common.exception.AuthenticationException;
+import api.buyhood.global.common.exception.enums.UserErrorCode;
 import java.util.Arrays;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -16,13 +18,7 @@ public enum UserRole {
 		return Arrays.stream(UserRole.values())
 			.filter(r -> r.name().equalsIgnoreCase(role) || r.getRole().equalsIgnoreCase(role))
 			.findFirst()
-			.orElseThrow(() -> new IllegalArgumentException("유효하지 않은 UserRole: " + role));
+			.orElseThrow(() -> new AuthenticationException(UserErrorCode.INVALID_USER_ROLE));
 	}
 
-	public static class Authority {
-
-		public static final String USER = "ROLE_USER";
-		public static final String SELLER = "ROLE_SELLER";
-
-	}
 }

--- a/src/main/java/api/buyhood/domain/user/enums/UserRole.java
+++ b/src/main/java/api/buyhood/domain/user/enums/UserRole.java
@@ -1,5 +1,6 @@
 package api.buyhood.domain.user.enums;
 
+import java.util.Arrays;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -11,5 +12,17 @@ public enum UserRole {
 
 	private final String role;
 
-	// 필요 시 of 메서드 구현
+	public static UserRole of(String role) {
+		return Arrays.stream(UserRole.values())
+			.filter(r -> r.name().equalsIgnoreCase(role) || r.getRole().equalsIgnoreCase(role))
+			.findFirst()
+			.orElseThrow(() -> new IllegalArgumentException("유효하지 않은 UserRole: " + role));
+	}
+
+	public static class Authority {
+
+		public static final String USER = "ROLE_USER";
+		public static final String SELLER = "ROLE_SELLER";
+
+	}
 }

--- a/src/main/java/api/buyhood/domain/user/repository/UserRepository.java
+++ b/src/main/java/api/buyhood/domain/user/repository/UserRepository.java
@@ -5,4 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserRepository extends JpaRepository<User, Long> {
 
+	boolean existsByEmail(String email);
 }

--- a/src/main/java/api/buyhood/domain/user/repository/UserRepository.java
+++ b/src/main/java/api/buyhood/domain/user/repository/UserRepository.java
@@ -1,9 +1,15 @@
 package api.buyhood.domain.user.repository;
 
 import api.buyhood.domain.user.entity.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface UserRepository extends JpaRepository<User, Long> {
 
 	boolean existsByEmail(String email);
+
+	@Query("SELECT u FROM User u WHERE u.deletedAt IS NULL ")
+	Page<User> findAllActiveUsers(Pageable pageable);
 }

--- a/src/main/java/api/buyhood/domain/user/service/UserService.java
+++ b/src/main/java/api/buyhood/domain/user/service/UserService.java
@@ -1,0 +1,14 @@
+package api.buyhood.domain.user.service;
+
+import api.buyhood.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+	private final UserRepository userRepository;
+
+
+}

--- a/src/main/java/api/buyhood/domain/user/service/UserService.java
+++ b/src/main/java/api/buyhood/domain/user/service/UserService.java
@@ -1,8 +1,15 @@
 package api.buyhood.domain.user.service;
 
+import api.buyhood.domain.user.dto.res.GetUserRes;
+import api.buyhood.domain.user.entity.User;
 import api.buyhood.domain.user.repository.UserRepository;
+import api.buyhood.global.common.exception.NotFoundException;
+import api.buyhood.global.common.exception.enums.UserErrorCode;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -10,5 +17,19 @@ public class UserService {
 
 	private final UserRepository userRepository;
 
+	//단건 조회
+	@Transactional(readOnly = true)
+	public GetUserRes getUser(Long id) {
+		User user = userRepository.findById(id)
+			.orElseThrow(() -> new NotFoundException(UserErrorCode.USER_NOT_FOUND));
 
+		return GetUserRes.of(user);
+	}
+
+	//다건 조회
+	@Transactional(readOnly = true)
+	public Page<GetUserRes> getAllUsers(int page, int size) {
+		Page<User> users = userRepository.findAllActiveUsers(PageRequest.of(page, size));
+		return users.map(GetUserRes::of);
+	}
 }

--- a/src/main/java/api/buyhood/global/common/exception/AuthenticationException.java
+++ b/src/main/java/api/buyhood/global/common/exception/AuthenticationException.java
@@ -1,0 +1,10 @@
+package api.buyhood.global.common.exception;
+
+import api.buyhood.global.common.exception.enums.ErrorCode;
+
+public class AuthenticationException extends BaseException {
+
+	public AuthenticationException(ErrorCode errorCode) {
+		super(errorCode);
+	}
+}

--- a/src/main/java/api/buyhood/global/common/exception/ConflictException.java
+++ b/src/main/java/api/buyhood/global/common/exception/ConflictException.java
@@ -1,0 +1,10 @@
+package api.buyhood.global.common.exception;
+
+import api.buyhood.global.common.exception.enums.ErrorCode;
+
+public class ConflictException extends BaseException {
+
+	public ConflictException(ErrorCode errorCode) {
+		super(errorCode);
+	}
+}

--- a/src/main/java/api/buyhood/global/common/exception/enums/AuthErrorCode.java
+++ b/src/main/java/api/buyhood/global/common/exception/enums/AuthErrorCode.java
@@ -1,0 +1,16 @@
+package api.buyhood.global.common.exception.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum AuthErrorCode implements ErrorCode {
+
+	INVALID_TOKEN(10, "만료된 토큰입니다.", ""),
+	EMAIL_DUPLICATED(9, "이미 가입된 이메일입니다.", "");
+
+	private final int code;
+	private final String message;
+	private final String detail;
+}

--- a/src/main/java/api/buyhood/global/common/exception/enums/AuthErrorCode.java
+++ b/src/main/java/api/buyhood/global/common/exception/enums/AuthErrorCode.java
@@ -2,15 +2,16 @@ package api.buyhood.global.common.exception.enums;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 
 @Getter
 @RequiredArgsConstructor
 public enum AuthErrorCode implements ErrorCode {
 
-	INVALID_TOKEN(10, "만료된 토큰입니다.", ""),
-	EMAIL_DUPLICATED(9, "이미 가입된 이메일입니다.", "");
+	INVALID_TOKEN(10, "만료된 토큰입니다.", HttpStatus.UNAUTHORIZED),
+	EMAIL_DUPLICATED(9, "이미 가입된 이메일입니다.", HttpStatus.CONFLICT);
 
 	private final int code;
 	private final String message;
-	private final String detail;
+	private final HttpStatus status;
 }

--- a/src/main/java/api/buyhood/global/common/exception/enums/AuthErrorCode.java
+++ b/src/main/java/api/buyhood/global/common/exception/enums/AuthErrorCode.java
@@ -7,9 +7,9 @@ import org.springframework.http.HttpStatus;
 @Getter
 @RequiredArgsConstructor
 public enum AuthErrorCode implements ErrorCode {
-
-	INVALID_TOKEN(10, "만료된 토큰입니다.", HttpStatus.UNAUTHORIZED),
-	EMAIL_DUPLICATED(9, "이미 가입된 이메일입니다.", HttpStatus.CONFLICT);
+	//에러코드 1300번대 사용 예정
+	INVALID_TOKEN(1301, "만료된 토큰입니다.", HttpStatus.UNAUTHORIZED),
+	EMAIL_DUPLICATED(1302, "이미 가입된 이메일입니다.", HttpStatus.CONFLICT);
 
 	private final int code;
 	private final String message;

--- a/src/main/java/api/buyhood/global/common/exception/enums/SellerErrorCode.java
+++ b/src/main/java/api/buyhood/global/common/exception/enums/SellerErrorCode.java
@@ -7,7 +7,7 @@ import org.springframework.http.HttpStatus;
 @Getter
 @RequiredArgsConstructor
 public enum SellerErrorCode implements ErrorCode {
-
+	//에러코드 1500번대 사용예정
 	;
 
 	private final int code;

--- a/src/main/java/api/buyhood/global/common/exception/enums/UserErrorCode.java
+++ b/src/main/java/api/buyhood/global/common/exception/enums/UserErrorCode.java
@@ -8,6 +8,7 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum UserErrorCode implements ErrorCode {
 	//에러코드 1400번대 사용예정
+	USER_NOT_FOUND(1402, "해당 유저를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
 	INVALID_USER_ROLE(1401, "유효하지 않은 UserRole 입니다.", HttpStatus.UNAUTHORIZED);
 
 	private final int code;

--- a/src/main/java/api/buyhood/global/common/exception/enums/UserErrorCode.java
+++ b/src/main/java/api/buyhood/global/common/exception/enums/UserErrorCode.java
@@ -7,8 +7,8 @@ import org.springframework.http.HttpStatus;
 @Getter
 @RequiredArgsConstructor
 public enum UserErrorCode implements ErrorCode {
-
-	;
+	//에러코드 1400번대 사용예정
+	INVALID_USER_ROLE(1401, "유효하지 않은 UserRole 입니다.", HttpStatus.UNAUTHORIZED);
 
 	private final int code;
 	private final String message;

--- a/src/main/java/api/buyhood/global/common/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/api/buyhood/global/common/filter/JwtAuthenticationFilter.java
@@ -1,0 +1,79 @@
+package api.buyhood.global.common.filter;
+
+import api.buyhood.domain.auth.entity.AuthUser;
+import api.buyhood.domain.user.enums.UserRole;
+import api.buyhood.global.common.util.JwtUtil;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.UnsupportedJwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+	private final JwtUtil jwtUtil;
+
+	@Override
+	protected void doFilterInternal(
+		@NonNull HttpServletRequest request,
+		@NonNull HttpServletResponse response,
+		@NonNull FilterChain filterChain
+	) throws ServletException, IOException {
+
+		String authHeader = request.getHeader("Authorization");
+
+		if (authHeader != null && authHeader.startsWith("Bearer ")) {
+			String token = authHeader.substring(7);
+			try {
+				Claims claims = jwtUtil.extractClaims(token);
+				if (SecurityContextHolder.getContext().getAuthentication() == null) {
+					setAuthentication(claims);
+				}
+			} catch (ExpiredJwtException e) {
+				log.error("Expired JWT token, 만료된 JWT 토큰입니다.", e);
+				response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "만료된 JWT 토큰입니다.");
+				return;
+			} catch (SecurityException | MalformedJwtException e) {
+				log.error("Invalid JWT signature, 유효하지 않은 JWT 서명입니다.", e);
+				response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "유효하지 않는 JWT 서명입니다.");
+				return;
+			} catch (UnsupportedJwtException e) {
+				log.error("Unsupported JWT token, 지원되지 않는 JWT 토큰 입니다.", e);
+				response.sendError(HttpServletResponse.SC_BAD_REQUEST, "지원되지 않는 JWT 토큰입니다.");
+				return;
+			} catch (Exception e) {
+				log.error("Internal server error", e);
+				response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+				return;
+			}
+		}
+		filterChain.doFilter(request, response);
+	}
+
+	private void setAuthentication(Claims claims) {
+		Long userId = Long.valueOf(claims.getSubject());
+		String email = claims.get("email", String.class);
+		UserRole userRole = UserRole.of(claims.get("role", String.class));
+
+		AuthUser authUser = new AuthUser(userId, email, userRole);
+		JwtAuthenticationToken authenticationToken = new JwtAuthenticationToken(authUser);
+
+		SecurityContextHolder.getContext().setAuthentication(authenticationToken);
+
+	}
+
+}
+

--- a/src/main/java/api/buyhood/global/common/filter/JwtAuthenticationToken.java
+++ b/src/main/java/api/buyhood/global/common/filter/JwtAuthenticationToken.java
@@ -1,0 +1,25 @@
+package api.buyhood.global.common.filter;
+
+import api.buyhood.domain.auth.entity.AuthUser;
+import org.springframework.security.authentication.AbstractAuthenticationToken;
+
+public class JwtAuthenticationToken extends AbstractAuthenticationToken {
+
+	private final AuthUser authUser;
+
+	public JwtAuthenticationToken(AuthUser authUser) {
+		super(authUser.getAuthorities());
+		this.authUser = authUser;
+		setAuthenticated(true);
+	}
+
+	@Override
+	public Object getCredentials() {
+		return null;
+	}
+
+	@Override
+	public Object getPrincipal() {
+		return authUser;
+	}
+}

--- a/src/main/java/api/buyhood/global/common/util/JwtUtil.java
+++ b/src/main/java/api/buyhood/global/common/util/JwtUtil.java
@@ -19,7 +19,6 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class JwtUtil {
 
-	private static final String BEARER_PREFIX = "Bearer ";
 	private static final long TOKEN_EXPIRATION_TIME = 60 * 1000L * 30 * 24; //30분 * 24
 
 	@Value("${jwt.secret.key}")
@@ -34,13 +33,15 @@ public class JwtUtil {
 		key = Keys.hmacShaKeyFor(bytes); // HS256 자동 인식
 	}
 
-	public String createToken(Long userId, String username, String email, UserRole role) {
+	public String createToken(String username, String email, UserRole role) {
+		Date now = new Date();
+
 		return Jwts.builder()
-			.subject(userId.toString())
+			.subject(email)
 			.claim("username", username)
-			.claim("email", email)
 			.claim("role", role.toString())
 			.expiration(new Date(System.currentTimeMillis() + TOKEN_EXPIRATION_TIME))
+			.issuedAt(now)
 			.signWith(key)
 			.compact();
 	}

--- a/src/main/java/api/buyhood/global/common/util/JwtUtil.java
+++ b/src/main/java/api/buyhood/global/common/util/JwtUtil.java
@@ -1,0 +1,55 @@
+package api.buyhood.global.common.util;
+
+import api.buyhood.domain.user.enums.UserRole;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import java.security.Key;
+import java.util.Base64;
+import java.util.Date;
+import javax.crypto.SecretKey;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtUtil {
+
+	private static final String BEARER_PREFIX = "Bearer ";
+	private static final long TOKEN_EXPIRATION_TIME = 60 * 1000L * 30 * 24; //30분 * 24
+
+	@Value("${jwt.secret.key}")
+	private String secretKey;
+	private Key key;
+
+	//0.12버전부터 SignatureAlgorithm 따로 설정할필요없이 Key가 자동으로 인식함.
+
+	@PostConstruct
+	public void init() {
+		byte[] bytes = Base64.getDecoder().decode(secretKey);
+		key = Keys.hmacShaKeyFor(bytes); // HS256 자동 인식
+	}
+
+	public String createToken(Long userId, String username, String email, UserRole role) {
+		return Jwts.builder()
+			.subject(userId.toString())
+			.claim("username", username)
+			.claim("email", email)
+			.claim("role", role.toString())
+			.expiration(new Date(System.currentTimeMillis() + TOKEN_EXPIRATION_TIME))
+			.signWith(key)
+			.compact();
+	}
+
+	public Claims extractClaims(String token) {
+		return Jwts.parser()
+			.verifyWith((SecretKey) key)
+			.build()
+			.parseSignedClaims(token)
+			.getPayload();
+	}
+}

--- a/src/main/java/api/buyhood/global/config/SecurityConfig.java
+++ b/src/main/java/api/buyhood/global/config/SecurityConfig.java
@@ -1,0 +1,48 @@
+package api.buyhood.global.config;
+
+import api.buyhood.global.common.filter.JwtAuthenticationFilter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.servletapi.SecurityContextHolderAwareRequestFilter;
+
+@Configuration
+@RequiredArgsConstructor
+@EnableWebSecurity
+@EnableMethodSecurity(securedEnabled = true)
+public class SecurityConfig {
+
+	private final JwtAuthenticationFilter jwtAuthenticationFilter;
+
+	@Bean
+	public PasswordEncoder passwordEncoder() {
+		return new BCryptPasswordEncoder();
+	}
+
+	@Bean
+	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+		http
+			.csrf(AbstractHttpConfigurer::disable)
+			.sessionManagement(session -> session
+				.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+			.authorizeHttpRequests(auth -> auth
+				.anyRequest().permitAll()
+			)
+			.formLogin(AbstractHttpConfigurer::disable)
+			.anonymous(AbstractHttpConfigurer::disable)
+			.httpBasic(AbstractHttpConfigurer::disable)
+			.logout(AbstractHttpConfigurer::disable)
+			.rememberMe(AbstractHttpConfigurer::disable)
+			.addFilterBefore(jwtAuthenticationFilter, SecurityContextHolderAwareRequestFilter.class);
+
+		return http.build();
+	}
+}


### PR DESCRIPTION
## 📌 PR 요약

- 유저 도메인에서 다건, 단건 조회 기능 구현했습니다

## 🔗 관련 이슈

MFLP-21

## 🛠️ 작업 내역

- 작업 내역을 bullet으로 작성해주세요.
    - 유저 단건 조회
    - 유저 다건 조회
    - 탈퇴유저 조회되지 않게 하였음.

## 📸 스크린샷 (선택)

작업 결과를 스크린샷으로 첨부해주세요.

| 기능  | 스크린샷               |
|-----|--------------------|

| 다건 성공| ![다건조회](https://github.com/user-attachments/assets/63539d97-a16e-4b27-a839-b9ed019ac40b) |
| 단건 성공 | ![단건조회](https://github.com/user-attachments/assets/273a46a5-36b0-4cce-b5ff-8a9d92a6cdbe) |
| 예외처리 | ![없는 유저 조회시](https://github.com/user-attachments/assets/39d3fa03-8e3a-4394-8be4-95946fe8296b) |

## ⚠️ 주의 사항 (선택)

리뷰어가 알아야 할 중요한 사항이나 주의할 점을 작성해주세요.

## ✅ 체크리스트

PR 작성자가 확인해야 할 항목입니다:

- [X] 코드가 정상적으로 동작하는지 확인했습니다.
- [X] 코드 리뷰어를 등록했습니다.
- [X] Labels를 등록했습니다.