### PR TITLE
feat(MFLP-25): Developing Create Order

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,52 @@
+name: Deploy to EC2
+
+on:
+  push:
+    branches:
+      - develop
+  pull_request:
+    branches:
+      - develop
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+
+    - name: Set up JDK 21
+      uses: actions/setup-java@v3
+      with:
+        distribution: 'temurin'
+        java-version: '21'
+
+    - name: Save SSH key
+      run: |
+        mkdir -p ~/.ssh
+        echo "${{ secrets.EC2_KEY }}" > ~/.ssh/deploy_key.pem
+        chmod 600 ~/.ssh/deploy_key.pem
+
+    - name: Grant execute permission to Gradle wrapper
+      run: chmod +x ./gradlew
+
+    - name: Build with Gradle
+      run: ./gradlew clean build
+
+    - name: Copy JAR file to EC2
+      run: |
+        scp -i ~/.ssh/deploy_key.pem -o StrictHostKeyChecking=no \
+        build/libs/*.jar \
+        ${{ secrets.EC2_USER }}@${{ secrets.EC2_HOST }}:/home/${{ secrets.EC2_USER }}/app.jar
+
+    - name: Deploy on EC2 via SSH
+      run: |
+        ssh -i ~/.ssh/deploy_key.pem -o StrictHostKeyChecking=no \
+        ${{ secrets.EC2_USER }}@${{ secrets.EC2_HOST }} << 'EOF'
+          echo "EC2 접속 성공"
+          pkill -f 'java -jar' || true
+          nohup java -jar /home/${{ secrets.EC2_USER }}/app.jar > app.log 2>&1 &
+          echo "JAR 실행 완료. 로그 보기:"
+          tail -n 10 app.log || echo "아직 로그 없음"
+        EOF

--- a/src/main/java/api/buyhood/domain/order/controller/OrderController.java
+++ b/src/main/java/api/buyhood/domain/order/controller/OrderController.java
@@ -1,0 +1,34 @@
+package api.buyhood.domain.order.controller;
+
+import api.buyhood.domain.order.dto.request.CreateOrderReq;
+import api.buyhood.domain.order.dto.response.CreateOrderRes;
+import api.buyhood.domain.order.service.OrderService;
+import api.buyhood.global.common.dto.Response;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+//todo: AuthUser 정보 추가
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class OrderController {
+
+    private final OrderService orderService;
+
+    /**
+     * 주문 생성
+     * todo: AuthUser 추후 추가
+     */
+
+    @PostMapping("/v1/orders")
+    public Response<CreateOrderRes> createOrder(
+            @Valid @RequestBody CreateOrderReq createOrderReq
+    ) {
+        return Response.ok(orderService.createOrder(createOrderReq));
+    }
+
+}

--- a/src/main/java/api/buyhood/domain/order/dto/request/CreateOrderReq.java
+++ b/src/main/java/api/buyhood/domain/order/dto/request/CreateOrderReq.java
@@ -1,0 +1,22 @@
+package api.buyhood.domain.order.dto.request;
+
+import api.buyhood.domain.order.enums.PaymentMethod;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@RequiredArgsConstructor
+public class CreateOrderReq {
+    @NotNull
+    private final PaymentMethod paymentMethod;
+
+    @NotNull
+    private final LocalDateTime pickupAt;
+
+    @NotNull
+    private final Long storeId;
+}

--- a/src/main/java/api/buyhood/domain/order/dto/response/CreateOrderRes.java
+++ b/src/main/java/api/buyhood/domain/order/dto/response/CreateOrderRes.java
@@ -1,0 +1,43 @@
+package api.buyhood.domain.order.dto.response;
+
+import api.buyhood.domain.cart.dto.response.CartRes;
+import api.buyhood.domain.order.enums.OrderStatus;
+import api.buyhood.domain.order.enums.PaymentMethod;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class CreateOrderRes {
+    private Long storeId;
+    private CartRes orderInfo;
+    private long totalPrice;
+    private PaymentMethod paymentMethod;
+    private OrderStatus status;
+    private LocalDateTime pickupAt;
+    private LocalDateTime createAt;
+
+    @Builder
+    private CreateOrderRes(Long storeId, CartRes orderInfo, long totalPrice, PaymentMethod paymentMethod, OrderStatus status, LocalDateTime pickupAt, LocalDateTime createAt) {
+        this.storeId = storeId;
+        this.orderInfo = orderInfo;
+        this.totalPrice = totalPrice;
+        this.paymentMethod = paymentMethod;
+        this.status = status;
+        this.pickupAt = pickupAt;
+        this.createAt = createAt;
+    }
+
+    public static CreateOrderRes of (Long storeId, CartRes orderInfo, long totalPrice, PaymentMethod paymentMethod, OrderStatus status, LocalDateTime pickupAt, LocalDateTime createAt) {
+        return CreateOrderRes.builder()
+                .storeId(storeId)
+                .orderInfo(orderInfo)
+                .totalPrice(totalPrice)
+                .paymentMethod(paymentMethod)
+                .status(status)
+                .pickupAt(pickupAt)
+                .createAt(createAt)
+                .build();
+    }
+}

--- a/src/main/java/api/buyhood/domain/order/entity/Order.java
+++ b/src/main/java/api/buyhood/domain/order/entity/Order.java
@@ -1,20 +1,16 @@
 package api.buyhood.domain.order.entity;
 
 import api.buyhood.domain.order.enums.OrderStatus;
+import api.buyhood.domain.order.enums.PaymentMethod;
+import api.buyhood.domain.store.entity.Store;
 import api.buyhood.global.common.entity.BaseTimeEntity;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.Table;
-import java.time.LocalDateTime;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
 
 @Entity
 @Getter
@@ -27,11 +23,16 @@ public class Order extends BaseTimeEntity {
 	@Column(nullable = false)
 	private Long id;
 
-	@Column
-	private String paymentMethod;
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "store_id")
+	private Store store;
 
 	@Column(nullable = false)
-	private Long totalPrice;
+	@Enumerated(EnumType.STRING)
+	private PaymentMethod paymentMethod;
+
+	@Column(nullable = false)
+	private long totalPrice;
 
 	@Column(nullable = false)
 	@Enumerated(EnumType.STRING)
@@ -40,11 +41,22 @@ public class Order extends BaseTimeEntity {
 	@Column
 	private LocalDateTime pickupAt;
 
+
 	@Builder
-	public Order(String paymentMethod, Long totalPrice, OrderStatus status, LocalDateTime pickupAt) {
+	public Order(Store store, PaymentMethod paymentMethod, long totalPrice, LocalDateTime pickupAt) {
+		this.store = store;
 		this.paymentMethod = paymentMethod;
 		this.totalPrice = totalPrice;
-		this.status = status;
+		this.status = OrderStatus.PENDING;
 		this.pickupAt = pickupAt;
+	}
+
+	public static Order of(Store store, PaymentMethod paymentMethod, long totalPrice, LocalDateTime pickupAt) {
+		return Order.builder()
+				.store(store)
+				.paymentMethod(paymentMethod)
+				.totalPrice(totalPrice)
+				.pickupAt(pickupAt)
+				.build();
 	}
 }

--- a/src/main/java/api/buyhood/domain/order/entity/OrderHistory.java
+++ b/src/main/java/api/buyhood/domain/order/entity/OrderHistory.java
@@ -1,0 +1,44 @@
+package api.buyhood.domain.order.entity;
+
+import api.buyhood.domain.product.entity.Product;
+import api.buyhood.global.common.entity.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "order_histories")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class OrderHistory extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(nullable = false)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "order_id")
+    private Order order;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "product_id")
+    private Product product;
+
+    @Column(nullable = false)
+    private int quantity;
+
+    @Builder
+    public OrderHistory (Order order, Product product, int quantity) {
+        this.order = order;
+        this.product = product;
+        this.quantity = quantity;
+    }
+
+    public static OrderHistory of(Order order, Product product, int quantity) {
+        return OrderHistory.builder()
+                .order(order)
+                .product(product)
+                .quantity(quantity)
+                .build();
+    }
+}

--- a/src/main/java/api/buyhood/domain/order/enums/PaymentMethod.java
+++ b/src/main/java/api/buyhood/domain/order/enums/PaymentMethod.java
@@ -1,0 +1,11 @@
+package api.buyhood.domain.order.enums;
+
+import lombok.Getter;
+
+@Getter
+public enum PaymentMethod {
+    LOCAL_QR,
+    LOCAL_CARD,
+    CREDIT_CARD,
+    ZERO_PAY
+}

--- a/src/main/java/api/buyhood/domain/order/repository/OrderHistoryRepoditory.java
+++ b/src/main/java/api/buyhood/domain/order/repository/OrderHistoryRepoditory.java
@@ -1,0 +1,7 @@
+package api.buyhood.domain.order.repository;
+
+import api.buyhood.domain.order.entity.OrderHistory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OrderHistoryRepoditory extends JpaRepository<OrderHistory, Long> {
+}

--- a/src/main/java/api/buyhood/domain/order/repository/OrderHistoryRepository.java
+++ b/src/main/java/api/buyhood/domain/order/repository/OrderHistoryRepository.java
@@ -3,5 +3,5 @@ package api.buyhood.domain.order.repository;
 import api.buyhood.domain.order.entity.OrderHistory;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface OrderHistoryRepoditory extends JpaRepository<OrderHistory, Long> {
+public interface OrderHistoryRepository extends JpaRepository<OrderHistory, Long> {
 }

--- a/src/main/java/api/buyhood/domain/order/service/OrderHistoryService.java
+++ b/src/main/java/api/buyhood/domain/order/service/OrderHistoryService.java
@@ -1,0 +1,30 @@
+package api.buyhood.domain.order.service;
+
+import api.buyhood.domain.cart.entity.Cart;
+import api.buyhood.domain.cart.entity.CartItem;
+import api.buyhood.domain.order.entity.Order;
+import api.buyhood.domain.order.entity.OrderHistory;
+import api.buyhood.domain.order.repository.OrderHistoryRepoditory;
+import api.buyhood.domain.product.entity.Product;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class OrderHistoryService {
+
+    private final OrderHistoryRepoditory orderHistoryRepoditory;
+
+    @Transactional
+    public void saveOrderHistory(Order order, Cart cart, Map<Long, Product> productMap) {
+
+        for (CartItem item : cart.getCart()) {
+            Product product = productMap.get(item.getProductId());
+            OrderHistory orderHistory = OrderHistory.of(order, product, item.getQuantity());
+            orderHistoryRepoditory.save(orderHistory);
+        }
+    }
+}

--- a/src/main/java/api/buyhood/domain/order/service/OrderHistoryService.java
+++ b/src/main/java/api/buyhood/domain/order/service/OrderHistoryService.java
@@ -4,7 +4,7 @@ import api.buyhood.domain.cart.entity.Cart;
 import api.buyhood.domain.cart.entity.CartItem;
 import api.buyhood.domain.order.entity.Order;
 import api.buyhood.domain.order.entity.OrderHistory;
-import api.buyhood.domain.order.repository.OrderHistoryRepoditory;
+import api.buyhood.domain.order.repository.OrderHistoryRepository;
 import api.buyhood.domain.product.entity.Product;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -16,7 +16,7 @@ import java.util.Map;
 @RequiredArgsConstructor
 public class OrderHistoryService {
 
-    private final OrderHistoryRepoditory orderHistoryRepoditory;
+    private final OrderHistoryRepository orderHistoryRepository;
 
     @Transactional
     public void saveOrderHistory(Order order, Cart cart, Map<Long, Product> productMap) {
@@ -24,7 +24,7 @@ public class OrderHistoryService {
         for (CartItem item : cart.getCart()) {
             Product product = productMap.get(item.getProductId());
             OrderHistory orderHistory = OrderHistory.of(order, product, item.getQuantity());
-            orderHistoryRepoditory.save(orderHistory);
+            orderHistoryRepository.save(orderHistory);
         }
     }
 }

--- a/src/main/java/api/buyhood/domain/order/service/OrderService.java
+++ b/src/main/java/api/buyhood/domain/order/service/OrderService.java
@@ -13,7 +13,6 @@ import api.buyhood.domain.product.repository.ProductRepository;
 import api.buyhood.domain.product.service.ProductService;
 import api.buyhood.domain.store.entity.Store;
 import api.buyhood.domain.store.repository.StoreRepository;
-import api.buyhood.global.common.exception.InvalidRequestException;
 import api.buyhood.global.common.exception.NotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -37,7 +36,7 @@ public class OrderService {
     private final StoreRepository storeRepository;
 
     @Transactional
-    public CreateOrderRes createOrder(CreateOrderReq createOrderReq) {
+    public CreateOrderRes createOrder(CreateOrderReq createOrderReq)  {
 
         Long userId = 1L;
 
@@ -45,7 +44,7 @@ public class OrderService {
                 .orElseThrow(() -> new NotFoundException(NOT_FOUND_STORE));
 
         if (!cartRepository.existsCart(userId)) {
-            throw  new InvalidRequestException(NOT_FOUND_CART);
+            throw new NotFoundException(NOT_FOUND_CART);
         }
 
         Cart cart = cartRepository.findCart(userId);

--- a/src/main/java/api/buyhood/domain/order/service/OrderService.java
+++ b/src/main/java/api/buyhood/domain/order/service/OrderService.java
@@ -1,0 +1,80 @@
+package api.buyhood.domain.order.service;
+
+import api.buyhood.domain.cart.dto.response.CartRes;
+import api.buyhood.domain.cart.entity.Cart;
+import api.buyhood.domain.cart.entity.CartItem;
+import api.buyhood.domain.cart.repository.CartRepository;
+import api.buyhood.domain.order.dto.request.CreateOrderReq;
+import api.buyhood.domain.order.dto.response.CreateOrderRes;
+import api.buyhood.domain.order.entity.Order;
+import api.buyhood.domain.order.repository.OrderRepository;
+import api.buyhood.domain.product.entity.Product;
+import api.buyhood.domain.product.repository.ProductRepository;
+import api.buyhood.domain.product.service.ProductService;
+import api.buyhood.domain.store.entity.Store;
+import api.buyhood.domain.store.repository.StoreRepository;
+import api.buyhood.global.common.exception.InvalidRequestException;
+import api.buyhood.global.common.exception.NotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static api.buyhood.global.common.exception.enums.CartErrorCode.NOT_FOUND_CART;
+import static api.buyhood.global.common.exception.enums.StoreErrorCode.NOT_FOUND_STORE;
+
+@Service
+@RequiredArgsConstructor
+public class OrderService {
+    private final OrderRepository orderRepository;
+    private final OrderHistoryService orderHistoryService;
+    private final CartRepository cartRepository;
+    private final ProductRepository productRepository;
+    private final ProductService productService;
+    private final StoreRepository storeRepository;
+
+    @Transactional
+    public CreateOrderRes createOrder(CreateOrderReq createOrderReq) {
+
+        Long userId = 1L;
+
+        Store store = storeRepository.findById(createOrderReq.getStoreId())
+                .orElseThrow(() -> new NotFoundException(NOT_FOUND_STORE));
+
+        if (!cartRepository.existsCart(userId)) {
+            throw  new InvalidRequestException(NOT_FOUND_CART);
+        }
+
+        Cart cart = cartRepository.findCart(userId);
+
+        List<Long> productIdList = cart.getCart().stream()
+                .map(CartItem::getProductId)
+                .toList();
+
+        Map<Long, Product> productMap = productRepository.findAllById(productIdList).stream()
+                .collect(Collectors.toMap(Product::getId, p -> p));
+
+        Order order = Order.of(store, createOrderReq.getPaymentMethod(), getTotalPrice(productMap, cart.getCart()), createOrderReq.getPickupAt());
+        orderRepository.save(order);
+        orderHistoryService.saveOrderHistory(order, cart, productMap);
+
+        productService.decreaseStock(cart, productMap);
+        cartRepository.clearCart(userId);
+
+        return CreateOrderRes.of(order.getStore().getId(), CartRes.of(cart),order.getTotalPrice(), order.getPaymentMethod(), order.getStatus(), order.getPickupAt(), order.getCreatedAt());
+    }
+
+    private long getTotalPrice(Map<Long, Product> productMap,List<CartItem> cartItemList) {
+        long totalPrice = 0L;
+
+        for (CartItem item : cartItemList) {
+            Product product = productMap.get(item.getProductId());
+            totalPrice += product.getPrice() * item.getQuantity();
+        }
+
+        return totalPrice;
+    }
+}

--- a/src/main/java/api/buyhood/domain/product/controller/ProductController.java
+++ b/src/main/java/api/buyhood/domain/product/controller/ProductController.java
@@ -1,14 +1,22 @@
 package api.buyhood.domain.product.controller;
 
 import api.buyhood.domain.product.dto.request.RegisteringProductReq;
+import api.buyhood.domain.product.dto.response.GetProductRes;
+import api.buyhood.domain.product.dto.response.PageProductRes;
 import api.buyhood.domain.product.dto.response.RegisteringProductRes;
 import api.buyhood.domain.product.service.ProductService;
 import api.buyhood.global.common.dto.Response;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -27,6 +35,27 @@ public class ProductController {
 			request.getCategoryId(),
 			request.getDescription()
 		);
+		return Response.ok(response);
+	}
+
+	@GetMapping("/v1/products/{productId}")
+	public Response<GetProductRes> getProduct(@PathVariable Long productId) {
+		GetProductRes response = productService.getProduct(productId);
+		return Response.ok(response);
+	}
+
+	@GetMapping("/v1/products")
+	public Response<Page<PageProductRes>> getAllProduct(@PageableDefault Pageable pageable) {
+		Page<PageProductRes> response = productService.getAllProducts(pageable);
+		return Response.ok(response);
+	}
+
+	@GetMapping("/v1/products/keyword")
+	public Response<Page<PageProductRes>> getProductByKeyword(
+		@RequestParam(required = false) String keyword,
+		@PageableDefault Pageable pageable
+	) {
+		Page<PageProductRes> response = productService.getProductByKeyword(keyword, pageable);
 		return Response.ok(response);
 	}
 }

--- a/src/main/java/api/buyhood/domain/product/dto/response/GetProductRes.java
+++ b/src/main/java/api/buyhood/domain/product/dto/response/GetProductRes.java
@@ -1,0 +1,30 @@
+package api.buyhood.domain.product.dto.response;
+
+import api.buyhood.domain.product.entity.Category;
+import api.buyhood.domain.product.entity.Product;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public class GetProductRes {
+
+	private final Long productId;
+	private final String productName;
+	private final Long price;
+	private final String categoryName;
+	private final String description;
+	private final Long stock;
+
+	public static GetProductRes of(Product product, Category category) {
+		return new GetProductRes(
+			product.getId(),
+			product.getName(),
+			product.getPrice(),
+			category.getName(),
+			product.getDescription(),
+			product.getStock()
+		);
+	}
+}

--- a/src/main/java/api/buyhood/domain/product/dto/response/PageProductRes.java
+++ b/src/main/java/api/buyhood/domain/product/dto/response/PageProductRes.java
@@ -1,0 +1,30 @@
+package api.buyhood.domain.product.dto.response;
+
+import api.buyhood.domain.product.entity.Product;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public class PageProductRes {
+
+	private final Long productId;
+	private final String productName;
+	private final Long price;
+	private final String categoryName;
+	private final Long stock;
+
+	public static Page<PageProductRes> of(Page<Product> productPage) {
+		return productPage.map(product ->
+			new PageProductRes(
+				product.getId(),
+				product.getName(),
+				product.getPrice(),
+				product.getCategory().getName(),
+				product.getStock()
+			)
+		);
+	}
+}

--- a/src/main/java/api/buyhood/domain/product/entity/Product.java
+++ b/src/main/java/api/buyhood/domain/product/entity/Product.java
@@ -1,20 +1,15 @@
 package api.buyhood.domain.product.entity;
 
 import api.buyhood.global.common.entity.BaseTimeEntity;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
+import api.buyhood.global.common.exception.InvalidRequestException;
+import jakarta.persistence.*;
 import jakarta.validation.constraints.Min;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import static api.buyhood.global.common.exception.enums.ProductErrorCode.OUT_OF_STOCK;
 
 @Entity
 @Getter
@@ -51,5 +46,15 @@ public class Product extends BaseTimeEntity {
 		this.category = category;
 		this.description = description;
 		this.stock = stock;
+	}
+
+	//재고 감소
+	public void decreaseStock (int quantity) {
+
+		if (stock < quantity) {
+			throw new InvalidRequestException(OUT_OF_STOCK);
+		}
+
+		this.stock -= quantity;
 	}
 }

--- a/src/main/java/api/buyhood/domain/product/repository/ProductRepository.java
+++ b/src/main/java/api/buyhood/domain/product/repository/ProductRepository.java
@@ -1,8 +1,16 @@
 package api.buyhood.domain.product.repository;
 
 import api.buyhood.domain.product.entity.Product;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface ProductRepository extends JpaRepository<Product, Long> {
 
+	@Query(
+		value = "select p from Product p join fetch p.category c where p.name like %:keyword%",
+		countQuery = "select count(p) from Product p where p.name like %:keyword%")
+	Page<Product> findByKeyword(@Param("keyword") String keyword, Pageable pageable);
 }

--- a/src/main/java/api/buyhood/domain/product/service/ProductService.java
+++ b/src/main/java/api/buyhood/domain/product/service/ProductService.java
@@ -1,5 +1,7 @@
 package api.buyhood.domain.product.service;
 
+import api.buyhood.domain.product.dto.response.GetProductRes;
+import api.buyhood.domain.product.dto.response.PageProductRes;
 import api.buyhood.domain.product.dto.response.RegisteringProductRes;
 import api.buyhood.domain.product.entity.Category;
 import api.buyhood.domain.product.entity.Product;
@@ -7,7 +9,12 @@ import api.buyhood.domain.product.repository.CategoryRepository;
 import api.buyhood.domain.product.repository.ProductRepository;
 import api.buyhood.global.common.exception.NotFoundException;
 import api.buyhood.global.common.exception.enums.CategoryErrorCode;
+import api.buyhood.global.common.exception.enums.ProductErrorCode;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort.Direction;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -45,4 +52,26 @@ public class ProductService {
 		return RegisteringProductRes.of(product, category != null ? category.getName() : null);
 	}
 
+	@Transactional(readOnly = true)
+	public GetProductRes getProduct(Long productId) {
+		Product product = productRepository.findById(productId)
+			.orElseThrow(() -> new NotFoundException(ProductErrorCode.PRODUCT_NOT_FOUND));
+		return GetProductRes.of(product, product.getCategory());
+	}
+
+	@Transactional(readOnly = true)
+	public Page<PageProductRes> getAllProducts(Pageable pageable) {
+		PageRequest pageRequest =
+			PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(), Direction.ASC, "name");
+		Page<Product> productPage = productRepository.findAll(pageRequest);
+		return PageProductRes.of(productPage);
+	}
+
+	@Transactional(readOnly = true)
+	public Page<PageProductRes> getProductByKeyword(String keyword, Pageable pageable) {
+		PageRequest pageRequest =
+			PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(), Direction.ASC, "name");
+		Page<Product> productPage = productRepository.findByKeyword(keyword, pageRequest);
+		return PageProductRes.of(productPage);
+	}
 }

--- a/src/main/java/api/buyhood/domain/product/service/ProductService.java
+++ b/src/main/java/api/buyhood/domain/product/service/ProductService.java
@@ -1,7 +1,7 @@
 package api.buyhood.domain.product.service;
 
-import api.buyhood.domain.product.dto.response.GetProductRes;
-import api.buyhood.domain.product.dto.response.PageProductRes;
+import api.buyhood.domain.cart.entity.Cart;
+import api.buyhood.domain.cart.entity.CartItem;
 import api.buyhood.domain.product.dto.response.RegisteringProductRes;
 import api.buyhood.domain.product.entity.Category;
 import api.buyhood.domain.product.entity.Product;
@@ -9,14 +9,11 @@ import api.buyhood.domain.product.repository.CategoryRepository;
 import api.buyhood.domain.product.repository.ProductRepository;
 import api.buyhood.global.common.exception.NotFoundException;
 import api.buyhood.global.common.exception.enums.CategoryErrorCode;
-import api.buyhood.global.common.exception.enums.ProductErrorCode;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort.Direction;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
@@ -74,4 +71,12 @@ public class ProductService {
 		Page<Product> productPage = productRepository.findByKeyword(keyword, pageRequest);
 		return PageProductRes.of(productPage);
 	}
+
+    @Transactional
+    public void decreaseStock(Cart cart, Map<Long, Product> productMap) {
+        for (CartItem cartItem : cart.getCart()) {
+            Product product = productMap.get(cartItem.getProductId());
+            product.decreaseStock(cartItem.getQuantity());
+        }
+    }
 }

--- a/src/main/java/api/buyhood/global/common/exception/enums/ProductErrorCode.java
+++ b/src/main/java/api/buyhood/global/common/exception/enums/ProductErrorCode.java
@@ -8,8 +8,9 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum ProductErrorCode implements ErrorCode {
 
-	PRODUCT_NOT_FOUND(2100, "상품을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
-	;
+	STOCK_UPDATE_CONFLICT(2000, "재고 변경 중 발생", HttpStatus.CONFLICT),
+	OUT_OF_STOCK(2000, "요청하신 수량보다 재고가 부족합니다.", HttpStatus.BAD_REQUEST),
+	NOT_FOUND_PRODUCT(2000, "상품이 존재하지 않습니다.", HttpStatus.NOT_FOUND);
 
 	private final int code;
 	private final String message;

--- a/src/main/java/api/buyhood/global/common/exception/enums/ProductErrorCode.java
+++ b/src/main/java/api/buyhood/global/common/exception/enums/ProductErrorCode.java
@@ -8,6 +8,7 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum ProductErrorCode implements ErrorCode {
 
+	PRODUCT_NOT_FOUND(2100, "상품을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
 	;
 
 	private final int code;

--- a/src/main/java/api/buyhood/global/common/exception/enums/StoreErrorCode.java
+++ b/src/main/java/api/buyhood/global/common/exception/enums/StoreErrorCode.java
@@ -8,7 +8,7 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum StoreErrorCode implements ErrorCode {
 
-	;
+	NOT_FOUND_STORE(2000, "가게가 존재하지 않습니다.", HttpStatus.NOT_FOUND);
 
 	private final int code;
 	private final String message;


### PR DESCRIPTION
## 📌 PR 요약

- 주문 생성 기능 (동시성 제어 ❌)
- 주문 내역을 관리하는 Entity 추가 (재고 롤백 시 사용)

## 🔗 관련 이슈

- 관련된 이슈 번호를 연결해주세요. (예: `closed #999`, `ref #999`)

## 🛠️ 작업 내역

- 작업 내역을 bullet으로 작성해주세요.
    - 주문 생성 기능 추가 

## 📸 스크린샷 (선택)

작업 결과를 스크린샷으로 첨부해주세요.

| 기능  | 스크린샷               |
|-----|--------------------|
| 주문 생성 성공 postman| ![image](https://github.com/user-attachments/assets/415c7d3c-ade0-4098-ba8d-16f1798aca2f)|
| 주문 생성 성공 DB|![image](https://github.com/user-attachments/assets/bf995db8-d2a9-4c63-99d4-b7795ca40669)|
| 주문 내역 생성 성공 DB|![image](https://github.com/user-attachments/assets/c93b1976-ce90-477f-a4b8-681678b6c0b8)|
| product 재고 감소 성공 100 -> 97|![image](https://github.com/user-attachments/assets/04802711-24b8-4a89-9440-7ea70f9a323c)|



## ⚠️ 주의 사항 (선택)

- 동시성 제어는 아직 구현하지 않았습니다. 
- 주문 취소 및 결제 취소 시 재고 롤백을 위한 OrderHistory를 추가하였습니다. 


## ✅ 체크리스트

PR 작성자가 확인해야 할 항목입니다:

- [x] 코드가 정상적으로 동작하는지 확인했습니다.
- [x] 코드 리뷰어를 등록했습니다.
- [x] Labels를 등록했습니다.