### PR TITLE
feat(MFLP-31): Implement the product modification API

### DIFF
--- a/src/main/java/api/buyhood/domain/product/controller/ProductController.java
+++ b/src/main/java/api/buyhood/domain/product/controller/ProductController.java
@@ -1,5 +1,6 @@
 package api.buyhood.domain.product.controller;
 
+import api.buyhood.domain.product.dto.request.PatchProductReq;
 import api.buyhood.domain.product.dto.request.RegisteringProductReq;
 import api.buyhood.domain.product.dto.response.GetProductRes;
 import api.buyhood.domain.product.dto.response.PageProductRes;
@@ -12,6 +13,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -57,5 +59,17 @@ public class ProductController {
 	) {
 		Page<PageProductRes> response = productService.getProductByKeyword(keyword, pageable);
 		return Response.ok(response);
+	}
+
+	@PatchMapping("/v1/products/{productId}")
+	public void patchProduct(@PathVariable Long productId, @RequestBody PatchProductReq request) {
+		productService.patchProduct(
+			productId,
+			request.getProductName(),
+			request.getPrice(),
+			request.getCategoryId(),
+			request.getDescription(),
+			request.getStock()
+		);
 	}
 }

--- a/src/main/java/api/buyhood/domain/product/dto/request/PatchProductReq.java
+++ b/src/main/java/api/buyhood/domain/product/dto/request/PatchProductReq.java
@@ -1,0 +1,15 @@
+package api.buyhood.domain.product.dto.request;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class PatchProductReq {
+
+	private final String productName;
+	private final Long price;
+	private final Long stock;
+	private final Long categoryId;
+	private final String description;
+}

--- a/src/main/java/api/buyhood/domain/product/entity/Product.java
+++ b/src/main/java/api/buyhood/domain/product/entity/Product.java
@@ -2,7 +2,15 @@ package api.buyhood.domain.product.entity;
 
 import api.buyhood.global.common.entity.BaseTimeEntity;
 import api.buyhood.global.common.exception.InvalidRequestException;
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
 import jakarta.validation.constraints.Min;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -49,12 +57,32 @@ public class Product extends BaseTimeEntity {
 	}
 
 	//재고 감소
-	public void decreaseStock (int quantity) {
+	public void decreaseStock(int quantity) {
 
 		if (stock < quantity) {
 			throw new InvalidRequestException(OUT_OF_STOCK);
 		}
 
 		this.stock -= quantity;
+	}
+
+	public void patchName(String productName) {
+		this.name = productName;
+	}
+
+	public void patchPrice(Long price) {
+		this.price = price;
+	}
+
+	public void patchCategory(Category category) {
+		this.category = category;
+	}
+
+	public void patchDescription(String description) {
+		this.description = description;
+	}
+
+	public void patchStock(Long stock) {
+		this.stock = stock;
 	}
 }

--- a/src/main/java/api/buyhood/domain/product/repository/ProductRepository.java
+++ b/src/main/java/api/buyhood/domain/product/repository/ProductRepository.java
@@ -13,4 +13,7 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
 		value = "select p from Product p join fetch p.category c where p.name like %:keyword%",
 		countQuery = "select count(p) from Product p where p.name like %:keyword%")
 	Page<Product> findByKeyword(@Param("keyword") String keyword, Pageable pageable);
+
+	@Query("select count(p) > 0 from Product p where p.name = :productName")
+	boolean existsByName(String productName);
 }

--- a/src/main/java/api/buyhood/domain/product/service/ProductService.java
+++ b/src/main/java/api/buyhood/domain/product/service/ProductService.java
@@ -2,18 +2,26 @@ package api.buyhood.domain.product.service;
 
 import api.buyhood.domain.cart.entity.Cart;
 import api.buyhood.domain.cart.entity.CartItem;
+import api.buyhood.domain.product.dto.response.GetProductRes;
+import api.buyhood.domain.product.dto.response.PageProductRes;
 import api.buyhood.domain.product.dto.response.RegisteringProductRes;
 import api.buyhood.domain.product.entity.Category;
 import api.buyhood.domain.product.entity.Product;
 import api.buyhood.domain.product.repository.CategoryRepository;
 import api.buyhood.domain.product.repository.ProductRepository;
+import api.buyhood.global.common.exception.ConflictException;
+import api.buyhood.global.common.exception.InvalidRequestException;
 import api.buyhood.global.common.exception.NotFoundException;
 import api.buyhood.global.common.exception.enums.CategoryErrorCode;
+import api.buyhood.global.common.exception.enums.ProductErrorCode;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort.Direction;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
@@ -72,11 +80,59 @@ public class ProductService {
 		return PageProductRes.of(productPage);
 	}
 
-    @Transactional
-    public void decreaseStock(Cart cart, Map<Long, Product> productMap) {
-        for (CartItem cartItem : cart.getCart()) {
-            Product product = productMap.get(cartItem.getProductId());
-            product.decreaseStock(cartItem.getQuantity());
-        }
-    }
+	@Transactional
+	public void patchProduct(
+		Long productId,
+		String productName,
+		Long price,
+		Long categoryId,
+		String description,
+		Long stock
+	) {
+		Product getProduct = productRepository.findById(productId)
+			.orElseThrow(() -> new NotFoundException(ProductErrorCode.PRODUCT_NOT_FOUND));
+
+		if (productName != null) {
+			if (getProduct.getName().equalsIgnoreCase(productName)) {
+				throw new InvalidRequestException(ProductErrorCode.PRODUCT_NAME_SAME_AS_OLD);
+			}
+
+			if (productRepository.existsByName(productName)) {
+				throw new ConflictException(ProductErrorCode.DUPLICATE_PRODUCT_NAME);
+			}
+
+			getProduct.patchName(productName);
+		}
+
+		if (price != null) {
+			getProduct.patchPrice(price);
+		}
+
+		if (description != null) {
+			getProduct.patchDescription(description);
+		}
+
+		if (stock != null) {
+			getProduct.patchStock(stock);
+		}
+
+		if (categoryId != null) {
+			if (categoryId == 0) {
+				getProduct.patchCategory(null);
+			} else {
+				Category getCategory = categoryRepository.findById(categoryId)
+					.orElseThrow(() -> new NotFoundException(CategoryErrorCode.CATEGORY_NOT_FOUND));
+				getProduct.patchCategory(getCategory);
+			}
+		}
+
+	}
+
+	@Transactional
+	public void decreaseStock(Cart cart, Map<Long, Product> productMap) {
+		for (CartItem cartItem : cart.getCart()) {
+			Product product = productMap.get(cartItem.getProductId());
+			product.decreaseStock(cartItem.getQuantity());
+		}
+	}
 }

--- a/src/main/java/api/buyhood/global/common/exception/enums/ProductErrorCode.java
+++ b/src/main/java/api/buyhood/global/common/exception/enums/ProductErrorCode.java
@@ -10,7 +10,9 @@ public enum ProductErrorCode implements ErrorCode {
 
 	STOCK_UPDATE_CONFLICT(2000, "재고 변경 중 발생", HttpStatus.CONFLICT),
 	OUT_OF_STOCK(2000, "요청하신 수량보다 재고가 부족합니다.", HttpStatus.BAD_REQUEST),
-	NOT_FOUND_PRODUCT(2000, "상품이 존재하지 않습니다.", HttpStatus.NOT_FOUND);
+	PRODUCT_NAME_SAME_AS_OLD(2001, "상품 이름이 이전과 동일합니다.", HttpStatus.BAD_REQUEST),
+	PRODUCT_NOT_FOUND(2401, "상품을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+	DUPLICATE_PRODUCT_NAME(2901, "중복된 상품 이름 입니다.", HttpStatus.CONFLICT);
 
 	private final int code;
 	private final String message;


### PR DESCRIPTION
## 📌 PR 요약

- 상품 수정 API 구현

## 🔗 관련 이슈

- MFLP-31

## 🛠️ 작업 내역

- 상품 수정 API 구현

## 📸 스크린샷 (선택)

작업 결과를 스크린샷으로 첨부해주세요.

| 기능  | 스크린샷               |
|-----|--------------------|
| 상품 수정 (이전 카테고리 그대로 사용) | ![스크린샷 2025-05-29 121122](https://github.com/user-attachments/assets/97241f94-0a49-4c95-a8e1-5f3108dcc2bb) |
| 상품 수정 (카테고리 제거) | ![스크린샷 2025-05-29 121212](https://github.com/user-attachments/assets/356ff223-95ed-42f7-9d99-247720740edc) |
| 상품 수정 (카테고리 제거 결과) | ![스크린샷 2025-05-29 121205](https://github.com/user-attachments/assets/9b88f82c-540a-4134-b884-58c9de4b82b5) |
| 상품 수정 실패 (상품 이름 이전과 동일) | ![image](https://github.com/user-attachments/assets/661db196-c1af-4ae2-af29-af772463b495) |
| 상품 수정 실패 (상품을 찾을 수 없음) | ![image](https://github.com/user-attachments/assets/ace73eaf-bcd3-4e23-87e7-151936152573) |
| 상품 수정 실패 (중복된 상품 이름) | ![image](https://github.com/user-attachments/assets/b548ac5a-4917-4a45-a866-b3dad5db83ed) |
| 상품 수정 실패 (카테고리를 찾을 수 없음) | ![image](https://github.com/user-attachments/assets/8a1647a4-7e28-47f1-a85e-0389a2b27848) |


## ⚠️ 주의 사항 (선택)

- Product 내 검증 로직 제거 필요
- Category 수정 시 이름 중복 로직 추가 필요
- Product가 카테고리를 여러 개 가질 수 있도록 할 지 고민 필요
   - 경우에 따라 조금 다를 수 있을 것 같음
      - ex 1) `식품, 두부` -> many to many
      - ex 2) `두부` -> many to one

## ✅ 체크리스트

PR 작성자가 확인해야 할 항목입니다:

- [x] 코드가 정상적으로 동작하는지 확인했습니다.
- [x] 코드 리뷰어를 등록했습니다.
- [x] Labels를 등록했습니다.