### PR TITLE
feat(MFLP-42): Implementing the store delete API

### DIFF
--- a/src/main/java/api/buyhood/domain/store/controller/StoreController.java
+++ b/src/main/java/api/buyhood/domain/store/controller/StoreController.java
@@ -12,6 +12,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -74,4 +75,10 @@ public class StoreController {
 			request.getClosedAt()
 		);
 	}
+
+	@DeleteMapping("/v1/stores/{storeId}")
+	public void deleteStore(@PathVariable Long storeId) {
+		storeService.deleteStore(storeId);
+	}
+
 }

--- a/src/main/java/api/buyhood/domain/store/service/StoreService.java
+++ b/src/main/java/api/buyhood/domain/store/service/StoreService.java
@@ -131,4 +131,12 @@ public class StoreService {
 			getStore.patchClosedAt(closedAt);
 		}
 	}
+
+	@Transactional
+	public void deleteStore(Long storeId) {
+		Store getStore = storeRepository.findById(storeId)
+			.orElseThrow(() -> new NotFoundException(StoreErrorCode.STORE_NOT_FOUND));
+
+		getStore.markDeleted();
+	}
 }


### PR DESCRIPTION
## 📌 PR 요약

- 가게 삭제 API 구현

## 🔗 관련 이슈

- MFLP-42

## 🛠️ 작업 내역

- 가게 삭제 구현

## 📸 스크린샷 (선택)

작업 결과를 스크린샷으로 첨부해주세요.

| 기능  | 스크린샷               |
|-----|--------------------|
| 가게 삭제 | ![스크린샷 2025-05-30 161029](https://github.com/user-attachments/assets/bc1c89a6-273c-4177-be03-3b7edd6bf790) |
| 가게 삭제 결과 | ![스크린샷 2025-05-30 161024](https://github.com/user-attachments/assets/1a3bd649-07bd-4cfd-b822-efa17c659c6c) |

## ⚠️ 주의 사항 (선택)

- 가게 삭제 시 사업자 검증 로직 추가 필요
- soft-delete 방식 사용에 따른 조회 로직 변경 필요

## ✅ 체크리스트

PR 작성자가 확인해야 할 항목입니다:

- [x] 코드가 정상적으로 동작하는지 확인했습니다.
- [x] 코드 리뷰어를 등록했습니다.
- [x] Labels를 등록했습니다.