### PR TITLE
feat(MFLP-36) : Implement changeSellerPassword & adding config path

### DIFF
--- a/src/main/java/api/buyhood/domain/auth/dto/req/SignInUserReq.java
+++ b/src/main/java/api/buyhood/domain/auth/dto/req/SignInUserReq.java
@@ -10,9 +10,9 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class SignInUserReq {
 
-	@NotBlank
+	@NotBlank(message = "이메일은 필수 입력값입니다.")
 	private String email;
-	@NotBlank
+	@NotBlank(message = "비밀번호는 필수 입력값입니다.")
 	private String password;
 
 }

--- a/src/main/java/api/buyhood/domain/auth/dto/req/SignupSellerReq.java
+++ b/src/main/java/api/buyhood/domain/auth/dto/req/SignupSellerReq.java
@@ -16,10 +16,10 @@ public class SignupSellerReq {
 	private String email;
 	@NotBlank(message = "비밀번호는 필수입력 값입니다.")
 	private String password;
-	@NotBlank(message = "유저 이름은 필수입력 값입니다.")
+	@NotBlank(message = "유저이름은 필수입력 값입니다.")
 	private String username;
 	@NotBlank(message = "사업자번호는 필수입력 값입니다.")
 	private String businessNumber;
-	@NotBlank(message = "휴대폰 번호는 필수 입력 값입니다.")
+	@NotBlank(message = "휴대폰번호는 필수 입력 값입니다.")
 	private String phoneNumber;
 }

--- a/src/main/java/api/buyhood/domain/auth/dto/req/SignupSellerReq.java
+++ b/src/main/java/api/buyhood/domain/auth/dto/req/SignupSellerReq.java
@@ -1,5 +1,7 @@
 package api.buyhood.domain.auth.dto.req;
 
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -9,10 +11,15 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class SignupSellerReq {
 
-	private String username;
+	@Email
+	@NotBlank(message = "이메일은 필수입력 값입니다.")
 	private String email;
+	@NotBlank(message = "비밀번호는 필수입력 값입니다.")
 	private String password;
+	@NotBlank(message = "유저 이름은 필수입력 값입니다.")
+	private String username;
+	@NotBlank(message = "사업자번호는 필수입력 값입니다.")
 	private String businessNumber;
-	private String businessName;
-	private String businessAddress;
+	@NotBlank(message = "휴대폰 번호는 필수 입력 값입니다.")
+	private String phoneNumber;
 }

--- a/src/main/java/api/buyhood/domain/auth/dto/req/SignupUserReq.java
+++ b/src/main/java/api/buyhood/domain/auth/dto/req/SignupUserReq.java
@@ -11,14 +11,17 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class SignupUserReq {
 
-	@NotBlank
+
 	@Email
+	@NotBlank(message = "이메일은 필수입력 값입니다.")
 	private String email;
-	@NotBlank
+	@NotBlank(message = "비밀번호는 필수입력 값입니다.")
 	private String password;
-	@NotBlank
+	@NotBlank(message = "유저 이름은 필수입력 값입니다.")
 	private String username;
-	@NotBlank
+	@NotBlank(message = "주소는 필수 입력 값입니다.")
 	private String address;
+	@NotBlank(message = "휴대폰 번호는 필수 입력 값입니다.")
+	private String phoneNumber;
 
 }

--- a/src/main/java/api/buyhood/domain/auth/service/AuthService.java
+++ b/src/main/java/api/buyhood/domain/auth/service/AuthService.java
@@ -37,6 +37,7 @@ public class AuthService {
 	private final PasswordEncoder passwordEncoder;
 	private final JwtUtil jwtUtil;
 
+	//유저회원가입
 	@Transactional
 	public SignupUserRes signUpUser(
 		SignupUserReq signupUserReq
@@ -50,8 +51,9 @@ public class AuthService {
 		User newUser = User.builder()
 			.email(signupUserReq.getEmail())
 			.password(encodedPassword)
-			.address(signupUserReq.getAddress())
 			.username(signupUserReq.getUsername())
+			.phoneNumber(signupUserReq.getPhoneNumber())
+			.address(signupUserReq.getAddress())
 			.build();
 
 		User savedUser = userRepository.save(newUser);
@@ -85,21 +87,20 @@ public class AuthService {
 
 	@Transactional
 	public SignupSellerRes signUpSeller(
-		SignupSellerReq signupSellerReq
+		SignupSellerReq req
 	) {
-		if (sellerRepository.existsByEmail(signupSellerReq.getEmail())) {
+		if (sellerRepository.existsByEmail(req.getEmail())) {
 			throw new ConflictException(SELLER_EMAIL_DUPLICATED);
 		}
 
-		String encodedPassword = passwordEncoder.encode(signupSellerReq.getPassword());
+		String encodedPassword = passwordEncoder.encode(req.getPassword());
 
 		Seller newSeller = Seller.builder()
-			.email(signupSellerReq.getEmail())
+			.email(req.getEmail())
 			.password(encodedPassword)
-			.businessName(signupSellerReq.getBusinessName())
-			.businessNumber(String.valueOf(signupSellerReq.getBusinessNumber()))
-			.businessAddress(signupSellerReq.getBusinessAddress())
-			.username(signupSellerReq.getUsername())
+			.username(req.getUsername())
+			.businessNumber(req.getBusinessNumber())
+			.phoneNumber(req.getPhoneNumber())
 			.build();
 
 		Seller savedSeller = sellerRepository.save(newSeller);

--- a/src/main/java/api/buyhood/domain/cart/dto/request/CartReq.java
+++ b/src/main/java/api/buyhood/domain/cart/dto/request/CartReq.java
@@ -10,7 +10,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class CartReq {
 
-	@NotNull(message = "제품 ID를 입력해주세요")
+	@NotNull(message = "상품 ID를 입력해주세요")
 	private Long productId;
 
 	@NotNull(message = "수량을 기입해주세요")

--- a/src/main/java/api/buyhood/domain/cart/dto/request/CartReq.java
+++ b/src/main/java/api/buyhood/domain/cart/dto/request/CartReq.java
@@ -10,9 +10,9 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class CartReq {
 
-	@NotNull
+	@NotNull(message = "제품 ID를 입력해주세요")
 	private Long productId;
 
-	@NotNull
+	@NotNull(message = "수량을 기입해주세요")
 	private int quantity;
 }

--- a/src/main/java/api/buyhood/domain/order/dto/request/AcceptOrderReq.java
+++ b/src/main/java/api/buyhood/domain/order/dto/request/AcceptOrderReq.java
@@ -1,5 +1,6 @@
 package api.buyhood.domain.order.dto.request;
 
+import jakarta.validation.constraints.NotNull;
 import java.time.LocalTime;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -8,6 +9,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class AcceptOrderReq {
 
+	@NotNull(message = "예상 준비시간을 입력해주세요.")
 	private final LocalTime readyAt;
 
 }

--- a/src/main/java/api/buyhood/domain/order/dto/request/ApplyOrderReq.java
+++ b/src/main/java/api/buyhood/domain/order/dto/request/ApplyOrderReq.java
@@ -9,9 +9,9 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class ApplyOrderReq {
 
-	@NotNull
+	@NotNull(message = "결제수단을 선택해주세요")
 	private final PaymentMethod paymentMethod;
-	@NotNull
+	@NotNull(message = "가게 Id를 입력해주세요")
 	private final Long storeId;
 	private final String requestMessage;
 }

--- a/src/main/java/api/buyhood/domain/seller/controller/SellerController.java
+++ b/src/main/java/api/buyhood/domain/seller/controller/SellerController.java
@@ -1,6 +1,7 @@
 package api.buyhood.domain.seller.controller;
 
 import api.buyhood.domain.auth.entity.AuthUser;
+import api.buyhood.domain.seller.dto.req.ChangeSellerPasswordReq;
 import api.buyhood.domain.seller.dto.req.DeleteSellerReq;
 import api.buyhood.domain.seller.dto.res.GetSellerRes;
 import api.buyhood.domain.seller.service.SellerService;
@@ -11,6 +12,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -50,5 +52,15 @@ public class SellerController {
 		sellerService.deleteSeller(authUser, req);
 
 		return Response.ok("회원탈퇴에 성공했습니다.");
+	}
+
+	//비밀번호 변경
+	@PatchMapping("/v1/sellers/password")
+	public Response<String> changePassword(
+		@AuthenticationPrincipal AuthUser authUser,
+		@RequestBody @Valid ChangeSellerPasswordReq req) {
+		sellerService.changePassword(authUser, req);
+
+		return Response.ok("비밀번호 변경에 성공했습니다.");
 	}
 }

--- a/src/main/java/api/buyhood/domain/seller/dto/req/ChangeSellerPasswordReq.java
+++ b/src/main/java/api/buyhood/domain/seller/dto/req/ChangeSellerPasswordReq.java
@@ -1,0 +1,21 @@
+package api.buyhood.domain.seller.dto.req;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ChangeSellerPasswordReq {
+
+	@NotBlank(message = "기존 비밀번호는 필수 입력값입니다.")
+	private String oldPassword;
+	@NotBlank(message = "새 비밀번호는 필수 입력값입니다.")
+	@Pattern(
+		regexp = "^(?=.*[A-Z])(?=.*\\d).{8,}$",
+		message = "비밀번호는 8자 이상, 숫자와 대문자를 포함해야 합니다."
+	)
+	private String newPassword;
+
+}

--- a/src/main/java/api/buyhood/domain/seller/dto/req/DeleteSellerReq.java
+++ b/src/main/java/api/buyhood/domain/seller/dto/req/DeleteSellerReq.java
@@ -8,6 +8,6 @@ import lombok.Getter;
 @AllArgsConstructor
 public class DeleteSellerReq {
 
-	@NotBlank
+	@NotBlank(message = "비밀번호를 입력해주세요")
 	private String password;
 }

--- a/src/main/java/api/buyhood/domain/seller/dto/res/GetSellerRes.java
+++ b/src/main/java/api/buyhood/domain/seller/dto/res/GetSellerRes.java
@@ -12,18 +12,16 @@ public class GetSellerRes {
 	private final String username;
 	private final String email;
 	private final String businessNumber;
-	private final String businessName;
-	private final String businessAddress;
 	private final UserRole role;
+	private final String phoneNumber;
 
 	public static GetSellerRes of(Seller seller) {
 		return new GetSellerRes(
 			seller.getUsername(),
 			seller.getEmail(),
 			seller.getBusinessNumber(),
-			seller.getBusinessName(),
-			seller.getBusinessAddress(),
-			seller.getRole()
+			seller.getRole(),
+			seller.getPhoneNumber()
 		);
 	}
 }

--- a/src/main/java/api/buyhood/domain/seller/entity/Seller.java
+++ b/src/main/java/api/buyhood/domain/seller/entity/Seller.java
@@ -39,34 +39,29 @@ public class Seller extends BaseTimeEntity {
 	private String businessNumber;
 
 	@Column(nullable = false)
-	private String businessName;
-
-	@Column(nullable = false)
-	private String businessAddress;
+	private String phoneNumber;
 
 	@Column(nullable = false)
 	@Enumerated(EnumType.STRING)
 	private UserRole role;
 
 	@Builder
-	public Seller(
-		String username,
-		String email,
-		String password,
-		String businessNumber,
-		String businessName,
-		String businessAddress
+	public Seller(String username, String email, String password, String businessNumber, String phoneNumber
 	) {
 		this.username = username;
 		this.email = email;
 		this.password = password;
 		this.businessNumber = businessNumber;
-		this.businessName = businessName;
-		this.businessAddress = businessAddress;
+		this.phoneNumber = phoneNumber;
 		this.role = UserRole.SELLER;
+	}
+
+	public void changePassword(String encodedPassword) {
+		this.password = encodedPassword;
 	}
 
 	public void deleteSeller() {
 		this.markDeleted();
 	}
+
 }

--- a/src/main/java/api/buyhood/domain/user/controller/UserController.java
+++ b/src/main/java/api/buyhood/domain/user/controller/UserController.java
@@ -1,7 +1,7 @@
 package api.buyhood.domain.user.controller;
 
 import api.buyhood.domain.auth.entity.AuthUser;
-import api.buyhood.domain.user.dto.req.ChangePasswordReq;
+import api.buyhood.domain.user.dto.req.ChangeUserPasswordReq;
 import api.buyhood.domain.user.dto.req.DeleteUserReq;
 import api.buyhood.domain.user.dto.req.PatchUserReq;
 import api.buyhood.domain.user.dto.res.GetUserRes;
@@ -50,7 +50,7 @@ public class UserController {
 	@PatchMapping("/v1/users/password")
 	public Response<String> changePassword(
 		@AuthenticationPrincipal AuthUser authUser,
-		@RequestBody @Valid ChangePasswordReq req) {
+		@RequestBody @Valid ChangeUserPasswordReq req) {
 		userService.changePassword(authUser, req);
 
 		return Response.ok("비밀번호 변경에 성공했습니다.");

--- a/src/main/java/api/buyhood/domain/user/dto/req/ChangeUserPasswordReq.java
+++ b/src/main/java/api/buyhood/domain/user/dto/req/ChangeUserPasswordReq.java
@@ -7,7 +7,7 @@ import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
-public class ChangePasswordReq {
+public class ChangeUserPasswordReq {
 
 	@NotBlank(message = "기존 비밀번호는 필수 입력값입니다.")
 	private String oldPassword;

--- a/src/main/java/api/buyhood/domain/user/entity/User.java
+++ b/src/main/java/api/buyhood/domain/user/entity/User.java
@@ -40,14 +40,18 @@ public class User extends BaseTimeEntity {
 	private UserRole role;
 
 	@Column(nullable = false)
+	private String phoneNumber;
+
+	@Column(nullable = false)
 	private String address;
 
 	@Builder
-	public User(String username, String email, String password, String address) {
+	public User(String username, String email, String password, String address, String phoneNumber) {
 		this.username = username;
 		this.email = email;
 		this.password = password;
 		this.role = UserRole.USER;
+		this.phoneNumber = phoneNumber;
 		this.address = address;
 	}
 

--- a/src/main/java/api/buyhood/domain/user/service/UserService.java
+++ b/src/main/java/api/buyhood/domain/user/service/UserService.java
@@ -1,7 +1,7 @@
 package api.buyhood.domain.user.service;
 
 import api.buyhood.domain.auth.entity.AuthUser;
-import api.buyhood.domain.user.dto.req.ChangePasswordReq;
+import api.buyhood.domain.user.dto.req.ChangeUserPasswordReq;
 import api.buyhood.domain.user.dto.req.DeleteUserReq;
 import api.buyhood.domain.user.dto.req.PatchUserReq;
 import api.buyhood.domain.user.dto.res.GetUserRes;
@@ -47,15 +47,15 @@ public class UserService {
 
 	//비밀번호 변경
 	@Transactional
-	public void changePassword(AuthUser authUser, ChangePasswordReq changePasswordReq) {
+	public void changePassword(AuthUser authUser, ChangeUserPasswordReq changeUserPasswordReq) {
 		User user = userRepository.findByEmail(authUser.getEmail())
 			.orElseThrow(() -> new NotFoundException(USER_NOT_FOUND));
 
-		validatePassword(changePasswordReq.getOldPassword(), user.getPassword());
-		if (passwordEncoder.matches(changePasswordReq.getNewPassword(), user.getPassword())) {
+		validatePassword(changeUserPasswordReq.getOldPassword(), user.getPassword());
+		if (passwordEncoder.matches(changeUserPasswordReq.getNewPassword(), user.getPassword())) {
 			throw new InvalidRequestException(PASSWORD_SAME_AS_OLD);
 		}
-		user.changePassword(passwordEncoder.encode(changePasswordReq.getNewPassword()));
+		user.changePassword(passwordEncoder.encode(changeUserPasswordReq.getNewPassword()));
 	}
 
 	//회원 정보 변경

--- a/src/main/java/api/buyhood/global/config/SecurityConfig.java
+++ b/src/main/java/api/buyhood/global/config/SecurityConfig.java
@@ -35,6 +35,8 @@ public class SecurityConfig {
 				.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
 			.authorizeHttpRequests(auth -> auth
 				.requestMatchers("/api/v1/auth/**", "/error").permitAll()
+				.requestMatchers("/v1/orders/{orderId}/accept", "/v1/orders/{orderId}/reject").hasRole("SELLER")
+				.requestMatchers("/api/v1/admin/**").hasRole("ADMIN")
 				.anyRequest().authenticated()
 			)
 			.formLogin(AbstractHttpConfigurer::disable)


### PR DESCRIPTION
## 📌 PR 요약

- SELLER 비밀번호 변경 로직 구현
- 그 외 req NotBlank 메세지
- Security Config 경로 설정 (사업자 전용 API 설정)

## 🔗 관련 이슈

MFLP-36

## 🛠️ 작업 내역

- 작업 내역을 bullet으로 작성해주세요.
    - 비밀번호 변경로직 구현

## 📸 스크린샷 (선택)

작업 결과를 스크린샷으로 첨부해주세요.

| 기능  | 스크린샷               |
|-----|--------------------|
| 성공| ![캡처](https://github.com/user-attachments/assets/7acfd25e-8df5-48b1-9fab-a5af0ae53408) |

## ⚠️ 주의 사항 (선택)

조회 기능을 permit경로에 넣고싶었는데 endpoint가 애매해서 남겨뒀습니다.
그 외에도 혹시 해당경로 permit이 필요하면 설정해주시면 되고 저한테 요청해도 됩니다

비밀번호 변경 로직은 User와 거의 99.99% 일치하기 때문에 예외처리 테스트사진은 안넣었습니다
(필요하시면 올려드리겠습니다.테스트는 해봄)

## ✅ 체크리스트

PR 작성자가 확인해야 할 항목입니다:

- [X] 코드가 정상적으로 동작하는지 확인했습니다.
- [X] 코드 리뷰어를 등록했습니다.
- [X] Labels를 등록했습니다.