### PR TITLE
fix(MFLP-48): Added API callability based on role

### DIFF
--- a/src/main/java/api/buyhood/domain/product/controller/CategoryController.java
+++ b/src/main/java/api/buyhood/domain/product/controller/CategoryController.java
@@ -12,6 +12,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.security.access.annotation.Secured;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -28,24 +29,28 @@ public class CategoryController {
 
 	private final CategoryService categoryService;
 
+	@Secured("ROLE_SELLER")
 	@PostMapping("/v1/categories")
 	public Response<CreateCategoryRes> createCategories(@Valid @RequestBody CreateCategoryReq request) {
-		CreateCategoryRes response = categoryService.createCategory(request.getCategoryName(), request.getParentId());
+		CreateCategoryRes response = categoryService.createCategory(request.getParentId(), request.getCategoryName());
 		return Response.ok(response);
 	}
 
+	@Secured("ROLE_SELLER")
 	@GetMapping("/v1/categories/{categoryId}")
 	public Response<GetCategoryRes> getCategory(@PathVariable Long categoryId) {
 		GetCategoryRes response = categoryService.getCategory(categoryId);
 		return Response.ok(response);
 	}
 
+	@Secured("ROLE_SELLER")
 	@GetMapping("/v1/categories")
 	public Response<Page<PageCategoryRes>> getAllCategories(@PageableDefault Pageable pageable) {
 		Page<PageCategoryRes> response = categoryService.getAllCategories(pageable);
 		return Response.ok(response);
 	}
 
+	@Secured("ROLE_SELLER")
 	@GetMapping("/v1/categories/depth/{depth}")
 	public Response<Page<PageCategoryRes>> getDepthCategories(
 		@PathVariable int depth,
@@ -55,6 +60,7 @@ public class CategoryController {
 		return Response.ok(response);
 	}
 
+	@Secured("ROLE_SELLER")
 	@PatchMapping("/v1/categories/{categoryId}")
 	public void patchCategory(
 		@PathVariable Long categoryId,
@@ -63,9 +69,10 @@ public class CategoryController {
 		categoryService.patchCategory(categoryId, request.getNewCategoryName());
 	}
 
+	@Secured("ROLE_SELLER")
 	@DeleteMapping("/v1/categories/{categoryId}")
 	public void deleteCategory(@PathVariable Long categoryId) {
 		categoryService.deleteCategory(categoryId);
 	}
-	
+
 }

--- a/src/main/java/api/buyhood/domain/product/entity/Category.java
+++ b/src/main/java/api/buyhood/domain/product/entity/Category.java
@@ -13,7 +13,6 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
-import jakarta.validation.constraints.Min;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -40,7 +39,6 @@ public class Category extends BaseTimeEntity {
 	private String name;
 
 	@Column(nullable = false)
-	@Min(0)
 	private int depth;
 
 	@ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/api/buyhood/domain/product/repository/CategoryRepository.java
+++ b/src/main/java/api/buyhood/domain/product/repository/CategoryRepository.java
@@ -15,7 +15,7 @@ public interface CategoryRepository extends JpaRepository<Category, Long> {
 			+ "where c.name = :categoryName "
 			+ "and ((:parentId = 0 and c.parent is null) "
 			+ "or (c.parent.id = :parentId))")
-	boolean existsByParentIdAndName(@Param("categoryName") String categoryName, @Param("parentId") Long parentId);
+	boolean existsByParentIdAndName(@Param("parentId") Long parentId, @Param("categoryName") String categoryName);
 
 	@Query("select c from Category c where c.depth = :depth")
 	Page<Category> getCategoriesByDepth(@Param("depth") int depth, Pageable pageable);

--- a/src/main/java/api/buyhood/domain/product/repository/CategoryRepository.java
+++ b/src/main/java/api/buyhood/domain/product/repository/CategoryRepository.java
@@ -9,15 +9,12 @@ import org.springframework.data.repository.query.Param;
 
 public interface CategoryRepository extends JpaRepository<Category, Long> {
 
-	@Query(
-		"select count(*) > 0 "
-			+ "from Category c "
-			+ "where c.name = :categoryName "
-			+ "and ((:parentId = 0 and c.parent is null) "
-			+ "or (c.parent.id = :parentId))")
+	@Query("select count(c) > 0 from Category c where c.name = :categoryName and c.parent.id = :parentId")
 	boolean existsByParentIdAndName(@Param("parentId") Long parentId, @Param("categoryName") String categoryName);
 
 	@Query("select c from Category c where c.depth = :depth")
 	Page<Category> getCategoriesByDepth(@Param("depth") int depth, Pageable pageable);
 
+	@Query("select count(c) > 0 from Category c where c.parent.id is null and c.name = :newCategoryName")
+	boolean existsByParentIsNullAndName(String newCategoryName);
 }

--- a/src/main/java/api/buyhood/global/common/exception/enums/CategoryErrorCode.java
+++ b/src/main/java/api/buyhood/global/common/exception/enums/CategoryErrorCode.java
@@ -9,8 +9,10 @@ import org.springframework.http.HttpStatus;
 public enum CategoryErrorCode implements ErrorCode {
 
 	MAX_DEPTH_OVER(1401, "더 이상 하위 카테고리를 만들 수 없습니다.", HttpStatus.BAD_REQUEST),
+	CATEGORY_NAME_SAME_AS_OLD(1402, "카테고리 이름이 이전과 동일합니다.", HttpStatus.BAD_REQUEST),
 	CATEGORY_NOT_FOUND(1440, "카테고리를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
-	DUPLICATE_CATEGORIES(1490, "중복된 카테고리 입니다.", HttpStatus.CONFLICT);
+	DUPLICATE_CATEGORIES(1490, "중복된 카테고리 입니다.", HttpStatus.CONFLICT),
+	;
 
 	private final int code;
 	private final String message;

--- a/src/main/java/api/buyhood/global/config/SecurityConfig.java
+++ b/src/main/java/api/buyhood/global/config/SecurityConfig.java
@@ -37,6 +37,9 @@ public class SecurityConfig {
 				.requestMatchers("/api/v1/auth/**", "/error").permitAll()
 				.anyRequest().authenticated()
 			)
+//			.authorizeHttpRequests(auth -> auth
+//				.anyRequest().permitAll()
+//			)
 			.formLogin(AbstractHttpConfigurer::disable)
 			.anonymous(AbstractHttpConfigurer::disable)
 			.httpBasic(AbstractHttpConfigurer::disable)


### PR DESCRIPTION
## 📌 PR 요약

- 역할에 따른 카테고리 API 호출 가능 여부 추가

## 🔗 관련 이슈

- MFLP-48

## 🛠️ 작업 내역

- CategoryController에 `@Secured` 추가
- 카테고리 생성 및 수정 로직에 카테고리 이름 중복 검사 로직 추가 및 변경

## 📸 스크린샷 (선택)

작업 결과를 스크린샷으로 첨부해주세요.

| 기능  | 스크린샷               |
|-----|--------------------|
| CategoryRepository | ![image](https://github.com/user-attachments/assets/d03b31fd-dcba-4683-ac1d-b7a3f9a79066) |

## ⚠️ 주의 사항 (선택)

- 최상위 카테고리인지 확인을 위해 `getParent()` 호출 시 NPE 발생으로 인해 중복 검사 로직을 수정 또는 추가했고, 기존 하나의 메서드로 동시에 체크하고 있던 것을 부모 카테고리가 있을 때와 없을 때의 두 가지로 나누어서 진행하도록 수정했습니다.
- 카테고리 관리를 전역적으로 할 것인지 또는 가게마다 별도로 관리하도록 할 것인지 정해야 합니다.
   - 전역적 관리의 경우 유저 역할에 관리자 역할 추가 필요 가능성
- 카테고리의 경우 물리적 삭제로 구현했기 때문에 별도의 `deletedAt` 체크를 `@Query`에 추가하지 않았습니다.

## ✅ 체크리스트

PR 작성자가 확인해야 할 항목입니다:

- [x] 코드가 정상적으로 동작하는지 확인했습니다.
- [x] 코드 리뷰어를 등록했습니다.
- [x] Labels를 등록했습니다.