### PR TITLE
refactor(MFLP-30): Add categoryId field to category ResponseDTO

### DIFF
--- a/src/main/java/api/buyhood/domain/product/dto/response/CreateCategoryRes.java
+++ b/src/main/java/api/buyhood/domain/product/dto/response/CreateCategoryRes.java
@@ -1,21 +1,21 @@
 package api.buyhood.domain.product.dto.response;
 
 import api.buyhood.domain.product.entity.Category;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 
 @Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public class CreateCategoryRes {
 
+	private final Long categoryId;
 	private final String parentName;
 	private final String categoryName;
 
-	private CreateCategoryRes(String parentName, String categoryName) {
-		this.parentName = parentName;
-		this.categoryName = categoryName;
-	}
-
 	public static CreateCategoryRes of(Category category) {
 		return new CreateCategoryRes(
+			category.getId(),
 			category.getParent() == null
 				? "root" : category.getParent().getName(),
 			category.getName()

--- a/src/main/java/api/buyhood/domain/product/dto/response/GetCategoryRes.java
+++ b/src/main/java/api/buyhood/domain/product/dto/response/GetCategoryRes.java
@@ -2,25 +2,23 @@ package api.buyhood.domain.product.dto.response;
 
 import api.buyhood.domain.product.entity.Category;
 import java.util.List;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 
 @Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public class GetCategoryRes {
 
+	private final Long categoryId;
 	private final int depth;
 	private final String parentName;
 	private final String categoryName;
 	private final List<String> childrenNames;
 
-	private GetCategoryRes(int depth, String parentName, String categoryName, List<String> childrenNames) {
-		this.depth = depth;
-		this.parentName = parentName;
-		this.categoryName = categoryName;
-		this.childrenNames = childrenNames;
-	}
-
 	public static GetCategoryRes of(Category category) {
 		return new GetCategoryRes(
+			category.getId(),
 			category.getDepth(),
 			category.getParent() == null
 				? "root" : category.getParent().getName(),

--- a/src/main/java/api/buyhood/domain/product/dto/response/PageCategoryRes.java
+++ b/src/main/java/api/buyhood/domain/product/dto/response/PageCategoryRes.java
@@ -1,22 +1,26 @@
 package api.buyhood.domain.product.dto.response;
 
 import api.buyhood.domain.product.entity.Category;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 
 @Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public class PageCategoryRes {
 
+	private final Long categoryId;
 	private final int depth;
 	private final String categoryName;
 
-	private PageCategoryRes(int depth, String categoryName) {
-		this.depth = depth;
-		this.categoryName = categoryName;
-	}
-
 	public static Page<PageCategoryRes> of(Page<Category> categoryPage) {
-		return categoryPage
-			.map(category -> new PageCategoryRes(category.getDepth(), category.getName()));
+		return categoryPage.map(category ->
+			new PageCategoryRes(
+				category.getId(),
+				category.getDepth(),
+				category.getName()
+			)
+		);
 	}
 }


### PR DESCRIPTION
## 📌 PR 요약

- 카테고리 ResponseDTO 클래스에 `categoryId` 필드 추가

## 🔗 관련 이슈

- MFLP-30

## 🛠️ 작업 내역

- `CreateCategoryRes`에 `categoryId` 추가
- `GetCategoryRes`에 `categoryId` 추가
- `PageCategoryRes`에 `categoryId` 추가

## 📸 스크린샷 (선택)

작업 결과를 스크린샷으로 첨부해주세요.

| 기능  | 스크린샷               |
|-----|--------------------|
| CreateCategoryRes | ![image](https://github.com/user-attachments/assets/e330b3f7-01ad-4ad5-8ea6-dcde6c59766e) |
| GetCategoryRes | ![image](https://github.com/user-attachments/assets/09d4fd9e-b644-4e6a-8910-3b30b23660ab) |
| PageCategoryRes | ![image](https://github.com/user-attachments/assets/de1c9ca5-aadd-49c1-9412-e32b6c9b7bd5) |

## ⚠️ 주의 사항 (선택)

리뷰어가 알아야 할 중요한 사항이나 주의할 점을 작성해주세요.

## ✅ 체크리스트

PR 작성자가 확인해야 할 항목입니다:

- [x] 코드가 정상적으로 동작하는지 확인했습니다.
- [x] 코드 리뷰어를 등록했습니다.
- [x] Labels를 등록했습니다.