### PR TITLE
refactor(MFLP-48): Category Domain refactoring

### DIFF
--- a/src/main/java/api/buyhood/domain/product/controller/CategoryController.java
+++ b/src/main/java/api/buyhood/domain/product/controller/CategoryController.java
@@ -12,6 +12,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.security.access.annotation.Secured;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -28,24 +29,28 @@ public class CategoryController {
 
 	private final CategoryService categoryService;
 
+	@Secured("ROLE_SELLER")
 	@PostMapping("/v1/categories")
 	public Response<CreateCategoryRes> createCategories(@Valid @RequestBody CreateCategoryReq request) {
 		CreateCategoryRes response = categoryService.createCategory(request.getCategoryName(), request.getParentId());
 		return Response.ok(response);
 	}
 
+	@Secured("ROLE_SELLER")
 	@GetMapping("/v1/categories/{categoryId}")
 	public Response<GetCategoryRes> getCategory(@PathVariable Long categoryId) {
 		GetCategoryRes response = categoryService.getCategory(categoryId);
 		return Response.ok(response);
 	}
 
+	@Secured("ROLE_SELLER")
 	@GetMapping("/v1/categories")
 	public Response<Page<PageCategoryRes>> getAllCategories(@PageableDefault Pageable pageable) {
 		Page<PageCategoryRes> response = categoryService.getAllCategories(pageable);
 		return Response.ok(response);
 	}
 
+	@Secured("ROLE_SELLER")
 	@GetMapping("/v1/categories/depth/{depth}")
 	public Response<Page<PageCategoryRes>> getDepthCategories(
 		@PathVariable int depth,
@@ -55,6 +60,7 @@ public class CategoryController {
 		return Response.ok(response);
 	}
 
+	@Secured("ROLE_SELLER")
 	@PatchMapping("/v1/categories/{categoryId}")
 	public void patchCategory(
 		@PathVariable Long categoryId,
@@ -63,9 +69,10 @@ public class CategoryController {
 		categoryService.patchCategory(categoryId, request.getNewCategoryName());
 	}
 
+	@Secured("ROLE_SELLER")
 	@DeleteMapping("/v1/categories/{categoryId}")
 	public void deleteCategory(@PathVariable Long categoryId) {
 		categoryService.deleteCategory(categoryId);
 	}
-	
+
 }

--- a/src/main/java/api/buyhood/domain/product/repository/CategoryRepository.java
+++ b/src/main/java/api/buyhood/domain/product/repository/CategoryRepository.java
@@ -11,17 +11,17 @@ import org.springframework.data.repository.query.Param;
 
 public interface CategoryRepository extends JpaRepository<Category, Long> {
 
-	@Query(
-		"select count(*) > 0 "
-			+ "from Category c "
-			+ "where c.name = :categoryName "
-			+ "and ((:parentId = 0 and c.parent is null) "
-			+ "or (c.parent.id = :parentId))")
-	boolean existsByParentIdAndName(@Param("categoryName") String categoryName, @Param("parentId") Long parentId);
+	@Query("select count(c) > 0 from Category c where c.parent.id = :parentId and c.name = :categoryName")
+	boolean existsByParentIdAndName(@Param("parentId") Long parentId, @Param("categoryName") String categoryName);
 
-	@Query("select c from Category c where c.depth = :depth")
+	@Query("select count(c) > 0 from Category c where c.parent.id is null and c.name = :categoryName")
+	boolean existsByParentIsNullAndName(String categoryName);
+
+	@Query(
+		value = "select c from Category c where c.depth = :depth",
+		countQuery = "select count(c) from Category c where c.depth = :depth")
 	Page<Category> getCategoriesByDepth(@Param("depth") int depth, Pageable pageable);
 
 	@Query("select c.name from Category c where c.id in :categoryIds")
-	List<String> findCategoryNamesByCategoryIds(@Param("categoryIds") Collection<Long> categoryIds);
+	List<String> findCategoryNamesByCategoryIds(Collection<Long> categoryIds);
 }

--- a/src/main/java/api/buyhood/domain/product/service/CategoryService.java
+++ b/src/main/java/api/buyhood/domain/product/service/CategoryService.java
@@ -6,6 +6,7 @@ import api.buyhood.domain.product.dto.response.PageCategoryRes;
 import api.buyhood.domain.product.entity.Category;
 import api.buyhood.domain.product.repository.CategoryProductRepository;
 import api.buyhood.domain.product.repository.CategoryRepository;
+import api.buyhood.global.common.exception.ConflictException;
 import api.buyhood.global.common.exception.InvalidRequestException;
 import api.buyhood.global.common.exception.NotFoundException;
 import api.buyhood.global.common.exception.enums.CategoryErrorCode;
@@ -24,16 +25,28 @@ public class CategoryService {
 	private final CategoryRepository categoryRepository;
 	private final CategoryProductRepository categoryProductRepository;
 
+	/**
+	 * 카테고리 생성
+	 *
+	 * @param categoryName 카테고리 이름 (필수)
+	 * @param parentId     부모 카테고리 ID 값 (선택)
+	 * @author dereck-jun
+	 */
 	@Transactional
 	public CreateCategoryRes createCategory(String categoryName, Long parentId) {
 		Category parent = null;
 		if (parentId != null && parentId != 0) {
 			parent = categoryRepository.findById(parentId)
 				.orElseThrow(() -> new NotFoundException(CategoryErrorCode.CATEGORY_NOT_FOUND));
-		}
-
-		if (categoryRepository.existsByParentIdAndName(categoryName, parentId)) {
-			throw new InvalidRequestException(CategoryErrorCode.DUPLICATE_CATEGORIES);
+			// 하위 카테고리 중복 체크
+			if (categoryRepository.existsByParentIdAndName(parentId, categoryName)) {
+				throw new InvalidRequestException(CategoryErrorCode.DUPLICATE_CATEGORIES);
+			}
+		} else {
+			// 최상위 카테고리 중복 체크
+			if (categoryRepository.existsByParentIsNullAndName(categoryName)) {
+				throw new InvalidRequestException(CategoryErrorCode.DUPLICATE_CATEGORIES);
+			}
 		}
 
 		int depth = parent == null ? 0 : parent.getDepth() + 1;
@@ -51,6 +64,12 @@ public class CategoryService {
 		return CreateCategoryRes.of(categoryRepository.save(category));
 	}
 
+	/**
+	 * 카테고리 단건 조회
+	 *
+	 * @param categoryId 조회할 카테고리 ID
+	 * @author dereck-jun
+	 */
 	@Transactional(readOnly = true)
 	public GetCategoryRes getCategory(Long categoryId) {
 		Category getCategory = categoryRepository.findById(categoryId)
@@ -58,6 +77,12 @@ public class CategoryService {
 		return GetCategoryRes.of(getCategory);
 	}
 
+	/**
+	 * 카테고리 전체 조회
+	 *
+	 * @param pageable
+	 * @author dereck-jun
+	 */
 	@Transactional(readOnly = true)
 	public Page<PageCategoryRes> getAllCategories(Pageable pageable) {
 		PageRequest pageRequest =
@@ -65,6 +90,13 @@ public class CategoryService {
 		return PageCategoryRes.of(categoryRepository.findAll(pageRequest));
 	}
 
+	/**
+	 * 카테고리 depth 별 조회
+	 *
+	 * @param depth    조회할 카테고리의 depth
+	 * @param pageable
+	 * @author dereck-jun
+	 */
 	@Transactional(readOnly = true)
 	public Page<PageCategoryRes> getDepthCategories(int depth, Pageable pageable) {
 		PageRequest pageRequest =
@@ -72,13 +104,40 @@ public class CategoryService {
 		return PageCategoryRes.of(categoryRepository.getCategoriesByDepth(depth, pageRequest));
 	}
 
+	/**
+	 * 카테고리 수정
+	 *
+	 * @param categoryId      수정할 카테고리 ID
+	 * @param newCategoryName 수정할 카테고리 이름
+	 * @author dereck-jun
+	 */
 	@Transactional
 	public void patchCategory(Long categoryId, String newCategoryName) {
 		Category getCategory = categoryRepository.findById(categoryId)
 			.orElseThrow(() -> new NotFoundException(CategoryErrorCode.CATEGORY_NOT_FOUND));
+
+		// 부모가 있으면, 해당 부모 아래에서 중복 체크
+		if (getCategory.getParent() != null) {
+			Long parentId = getCategory.getParent().getId();
+			if (categoryRepository.existsByParentIdAndName(parentId, newCategoryName)) {
+				throw new ConflictException(CategoryErrorCode.DUPLICATE_CATEGORIES);
+			}
+		} else {
+			// 부모가 없으면, 최상위 카테고리끼리 중복 체크
+			if (categoryRepository.existsByParentIsNullAndName(newCategoryName)) {
+				throw new ConflictException(CategoryErrorCode.DUPLICATE_CATEGORIES);
+			}
+		}
+
 		getCategory.patchCategory(newCategoryName);
 	}
 
+	/**
+	 * 카테고리 삭제 (물리적 삭제)
+	 *
+	 * @param categoryId 삭제할 카테고리 ID
+	 * @author dereck-jun
+	 */
 	@Transactional
 	public void deleteCategory(Long categoryId) {
 		Category getCategory = categoryRepository.findById(categoryId)


### PR DESCRIPTION
## 📌 PR 요약

- 카테고리 도메인 리팩토링

## 🔗 관련 이슈

- MFLP-48

## 🛠️ 작업 내역

- 카테고리 이름 중복성 검사 로직 수정
- `CategoryController`에 `@Secured` 추가

## 📸 스크린샷 (선택)

작업 결과를 스크린샷으로 첨부해주세요.

| 기능  | 스크린샷               |
|-----|--------------------|
| 미리 생성한 카테고리 | ![image](https://github.com/user-attachments/assets/3908e910-0b47-452d-8135-450e6db4d0ad) |
| 카테고리 생성 이름 중복 실패 (parentId != null && parentId == 0) | ![image](https://github.com/user-attachments/assets/b05e0024-2370-4a6e-a1c4-8bc2574e89eb) |
| 카테고리 생성 이름 중복 실패 (parentId == null) | ![image](https://github.com/user-attachments/assets/63efd22e-588e-4a08-96f8-eba0237c55c6) |
| 카테고리 수정 이름 중복 실패 (수정하려는 카테고리의 parent 값이 null)  | ![image](https://github.com/user-attachments/assets/f452a4ce-ad42-43bd-9562-4d19a998bf92) |
| 카테고리 수정 이름 중복 실패 (수정하려는 카테고리의 parent 값이 null이 아님) | ![image](https://github.com/user-attachments/assets/936ffd10-d0a0-4ad7-8251-7a38a59a402f) |

## ⚠️ 주의 사항 (선택)

- 카테고리를 전역적으로 관리하는 경우 관리자 역할이 추가로 필요할 것 같습니다.

## ✅ 체크리스트

PR 작성자가 확인해야 할 항목입니다:

- [x] 코드가 정상적으로 동작하는지 확인했습니다.
- [x] 코드 리뷰어를 등록했습니다.
- [x] Labels를 등록했습니다.