### PR TITLE
refactor(MFLP-49): Refactoring the shop domain

### DIFF
--- a/src/main/java/api/buyhood/domain/seller/repository/SellerRepository.java
+++ b/src/main/java/api/buyhood/domain/seller/repository/SellerRepository.java
@@ -17,4 +17,7 @@ public interface SellerRepository extends JpaRepository<Seller, Long> {
 
 	@Query("SELECT s FROM Seller s WHERE s.deletedAt IS NULL ")
 	Page<Seller> findAllActiveSellers(Pageable pageable);
+
+	@Query("SELECT s FROM Seller s WHERE s.id = :sellerId AND s.deletedAt IS NULL")
+	Optional<Seller> findActiveSellerById(@Param("sellerId") Long sellerId);
 }

--- a/src/main/java/api/buyhood/domain/store/controller/StoreController.java
+++ b/src/main/java/api/buyhood/domain/store/controller/StoreController.java
@@ -1,10 +1,11 @@
 package api.buyhood.domain.store.controller;
 
+import api.buyhood.domain.auth.entity.AuthUser;
 import api.buyhood.domain.store.dto.request.PatchStoreReq;
-import api.buyhood.domain.store.dto.request.RegisteringStoreReq;
+import api.buyhood.domain.store.dto.request.RegisterStoreReq;
 import api.buyhood.domain.store.dto.response.GetStoreRes;
 import api.buyhood.domain.store.dto.response.PageStoreRes;
-import api.buyhood.domain.store.dto.response.RegisteringStoreRes;
+import api.buyhood.domain.store.dto.response.RegisterStoreRes;
 import api.buyhood.domain.store.service.StoreService;
 import api.buyhood.global.common.dto.Response;
 import jakarta.validation.Valid;
@@ -12,6 +13,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -29,12 +32,17 @@ public class StoreController {
 
 	private final StoreService storeService;
 
+	@Secured("ROLE_SELLER")
 	@PostMapping("/v1/stores")
-	public Response<RegisteringStoreRes> registerStore(@Valid @RequestBody RegisteringStoreReq request) {
-		RegisteringStoreRes response = storeService.registerStore(
+	public Response<RegisterStoreRes> registerStore(
+		@AuthenticationPrincipal AuthUser currentUser,
+		@Valid @RequestBody RegisterStoreReq request
+	) {
+		RegisterStoreRes response = storeService.registerStore(
+			currentUser.getId(),
 			request.getStoreName(),
 			request.getAddress(),
-			request.getSellerId(),
+			request.getIsDeliverable(),
 			request.getDescription(),
 			request.getOpenedAt(),
 			request.getClosedAt()
@@ -63,22 +71,30 @@ public class StoreController {
 		return Response.ok(response);
 	}
 
+	@Secured("ROLE_SELLER")
 	@PatchMapping("/v1/stores/{storeId}")
-	public void patchStore(@PathVariable Long storeId, @RequestBody PatchStoreReq request) {
+	public void patchStore(
+		@AuthenticationPrincipal AuthUser currentUser,
+		@PathVariable Long storeId,
+		@RequestBody PatchStoreReq request
+	) {
 		storeService.patchStore(
+			currentUser.getId(),
 			storeId,
 			request.getStoreName(),
 			request.getAddress(),
 			request.getSellerId(),
+			request.getIsDeliverable(),
 			request.getDescription(),
 			request.getOpenedAt(),
 			request.getClosedAt()
 		);
 	}
 
+	@Secured("ROLE_SELLER")
 	@DeleteMapping("/v1/stores/{storeId}")
-	public void deleteStore(@PathVariable Long storeId) {
-		storeService.deleteStore(storeId);
+	public void deleteStore(@AuthenticationPrincipal AuthUser currentUser, @PathVariable Long storeId) {
+		storeService.deleteStore(currentUser.getId(), storeId);
 	}
 
 }

--- a/src/main/java/api/buyhood/domain/store/dto/request/PatchStoreReq.java
+++ b/src/main/java/api/buyhood/domain/store/dto/request/PatchStoreReq.java
@@ -11,6 +11,7 @@ public class PatchStoreReq {
 	private final String storeName;
 	private final String address;
 	private final Long sellerId;
+	private final Boolean isDeliverable;
 	private final String description;
 	private final LocalTime openedAt;
 	private final LocalTime closedAt;

--- a/src/main/java/api/buyhood/domain/store/dto/request/RegisterStoreReq.java
+++ b/src/main/java/api/buyhood/domain/store/dto/request/RegisterStoreReq.java
@@ -8,7 +8,7 @@ import lombok.RequiredArgsConstructor;
 
 @Getter
 @RequiredArgsConstructor
-public class RegisteringStoreReq {
+public class RegisterStoreReq {
 
 	@NotBlank(message = "가게 이름은 공백일 수 없습니다.")
 	private final String storeName;
@@ -16,8 +16,8 @@ public class RegisteringStoreReq {
 	@NotBlank(message = "주소는 공백일 수 없습니다.")
 	private final String address;
 
-	@NotNull
-	private final Long sellerId;
+	@NotNull(message = "배달 가능 여부는 공백일 수 없습니다.")
+	private final Boolean isDeliverable;
 
 	private final String description;
 	private final LocalTime openedAt;

--- a/src/main/java/api/buyhood/domain/store/dto/response/GetStoreRes.java
+++ b/src/main/java/api/buyhood/domain/store/dto/response/GetStoreRes.java
@@ -14,16 +14,18 @@ public class GetStoreRes {
 	private final String storeName;
 	private final String address;
 	private final Long sellerId;
+	private final boolean isDeliverable;
 	private final String description;
 	private final LocalTime openedAt;
 	private final LocalTime closedAt;
 
-	public static GetStoreRes of(Store store, Long sellerId) {
+	public static GetStoreRes of(Store store) {
 		return new GetStoreRes(
 			store.getId(),
 			store.getName(),
 			store.getAddress(),
-			sellerId,
+			store.getSeller().getId(),
+			store.isDeliverable(),
 			store.getDescription(),
 			store.getOpenedAt(),
 			store.getClosedAt()

--- a/src/main/java/api/buyhood/domain/store/dto/response/PageStoreRes.java
+++ b/src/main/java/api/buyhood/domain/store/dto/response/PageStoreRes.java
@@ -14,6 +14,7 @@ public class PageStoreRes {
 	private final Long storeId;
 	private final String storeName;
 	private final String address;
+	private final boolean isDeliverable;
 	private final LocalTime openedAt;
 	private final LocalTime closedAt;
 
@@ -23,6 +24,7 @@ public class PageStoreRes {
 				store.getId(),
 				store.getName(),
 				store.getAddress(),
+				store.isDeliverable(),
 				store.getOpenedAt(),
 				store.getClosedAt()
 			)

--- a/src/main/java/api/buyhood/domain/store/dto/response/RegisterStoreRes.java
+++ b/src/main/java/api/buyhood/domain/store/dto/response/RegisterStoreRes.java
@@ -8,22 +8,24 @@ import lombok.RequiredArgsConstructor;
 
 @Getter
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
-public class RegisteringStoreRes {
+public class RegisterStoreRes {
 
 	private final Long storeId;
 	private final String storeName;
 	private final String address;
 	private final Long sellerId;
+	private final boolean isDeliverable;
 	private final String description;
 	private final LocalTime openedAt;
 	private final LocalTime closedAt;
 
-	public static RegisteringStoreRes of(Store store, Long sellerId) {
-		return new RegisteringStoreRes(
+	public static RegisterStoreRes of(Store store, Long sellerId) {
+		return new RegisterStoreRes(
 			store.getId(),
 			store.getName(),
 			store.getAddress(),
 			sellerId,
+			store.isDeliverable(),
 			store.getDescription(),
 			store.getOpenedAt(),
 			store.getClosedAt()

--- a/src/main/java/api/buyhood/domain/store/entity/Store.java
+++ b/src/main/java/api/buyhood/domain/store/entity/Store.java
@@ -38,6 +38,9 @@ public class Store extends BaseTimeEntity {
 	@JoinColumn(name = "seller_id")
 	private Seller seller;
 
+	@Column(nullable = false)
+	private boolean isDeliverable;
+
 	@Column
 	private String description;
 
@@ -47,11 +50,13 @@ public class Store extends BaseTimeEntity {
 	@Column
 	private LocalTime closedAt;
 
+
 	@Builder
 	public Store(
 		String name,
 		String address,
 		Seller seller,
+		boolean isDeliverable,
 		String description,
 		LocalTime openedAt,
 		LocalTime closedAt
@@ -59,6 +64,7 @@ public class Store extends BaseTimeEntity {
 		this.name = name;
 		this.address = address;
 		this.seller = seller;
+		this.isDeliverable = isDeliverable;
 		this.description = description;
 		this.openedAt = openedAt;
 		this.closedAt = closedAt;
@@ -74,6 +80,10 @@ public class Store extends BaseTimeEntity {
 
 	public void patchSeller(Seller seller) {
 		this.seller = seller;
+	}
+
+	public void patchIsDeliverable(boolean isDeliverable) {
+		this.isDeliverable = isDeliverable;
 	}
 
 	public void patchDescription(String description) {

--- a/src/main/java/api/buyhood/domain/store/repository/StoreRepository.java
+++ b/src/main/java/api/buyhood/domain/store/repository/StoreRepository.java
@@ -12,17 +12,17 @@ public interface StoreRepository extends JpaRepository<Store, Long> {
 
 	boolean existsByName(String storeName);
 
-	@Query("select s from Store s inner join fetch s.seller where s.id = :storeId")
-	Optional<Store> findStoreById(Long storeId);
+	@Query("select s from Store s inner join fetch s.seller where s.id = :storeId and s.deletedAt is null")
+	Optional<Store> findActiveStoreByIdFetchSeller(Long storeId);
 
 	@Query(
-		value = "select s from Store s inner join fetch s.seller",
-		countQuery = "select count(s) from Store s")
-	Page<Store> findFetchAll(Pageable pageable);
+		value = "select s from Store s where s.deletedAt is null",
+		countQuery = "select count(s) from Store s where s.deletedAt is null")
+	Page<Store> findActiveStores(Pageable pageable);
 
 	@Query(
-		value = "select s from Store s inner join fetch s.seller where s.name like %:storeName%",
-		countQuery = "select count(s) from Store s where s.name like %:storeName%")
-	Page<Store> findByKeyword(@Param("storeName") String storeName, Pageable pageable);
+		value = "select s from Store s where s.name like %:storeName% and s.deletedAt is null",
+		countQuery = "select count(s) from Store s where s.name like %:storeName% and s.deletedAt is null")
+	Page<Store> findActiveStoresByNameLike(@Param("storeName") String storeName, Pageable pageable);
 
 }

--- a/src/main/java/api/buyhood/global/common/exception/enums/StoreErrorCode.java
+++ b/src/main/java/api/buyhood/global/common/exception/enums/StoreErrorCode.java
@@ -9,6 +9,7 @@ import org.springframework.http.HttpStatus;
 public enum StoreErrorCode implements ErrorCode {
 
 	STORE_NOT_FOUND(2000, "가게가 존재하지 않습니다.", HttpStatus.NOT_FOUND),
+	NOT_STORE_OWNER(3301, "해당 작업을 수행하기 위한 권한이 없습니다.", HttpStatus.FORBIDDEN),
 	DUPLICATE_STORE_NAME(3901, "중복된 가게 이름 입니다.", HttpStatus.CONFLICT),
 	STORE_NAME_SAME_AS_OLD(3902, "이전과 동일한 가게 이름 입니다.", HttpStatus.CONFLICT),
 	;


### PR DESCRIPTION
## 📌 PR 요약

- 가게 도메인 리팩토링

## 🔗 관련 이슈

- MFLP-49

## 🛠️ 작업 내역

- 특정 가게 API에 사용자 확인 로직 추가
- 가게 물리적 삭제를 논리적 삭제로 변경
- 가게가 배달을 지원하는지 확인하는 필드 추가
- 주석 추가

## 📸 스크린샷 (선택)

작업 결과를 스크린샷으로 첨부해주세요.

| 기능  | 스크린샷               |
|-----|--------------------|
| 가게 등록 | ![image](https://github.com/user-attachments/assets/cc8b0c30-b70c-4ef8-8f60-bcc7b544f4ca) |
| 가게 단건 조회 | ![image](https://github.com/user-attachments/assets/4e59bd0c-e8e8-44d3-9981-6bfe74cbe79f) |
| 가게 전체 조회 | ![image](https://github.com/user-attachments/assets/6b870a99-6edf-45dd-aa0c-85bdfda455ff) |
| 가게 키워드 조회 (가게 이름으로 조회) | ![image](https://github.com/user-attachments/assets/2c79168d-8ce6-438d-a3b8-42f7cbf45012) |
| 가게 수정 (가게 이름 및 사업자 변경) | ![image](https://github.com/user-attachments/assets/2704ec64-dd88-4e2d-ba55-f10d860c35f1) |
| 수정한 가게 기존 사업자가 삭제 시도 | ![image](https://github.com/user-attachments/assets/7e93e2c1-71bf-4b60-8e4a-149a0c9092f2) |
| 가게 삭제 | ![image](https://github.com/user-attachments/assets/39cd39aa-acc9-418d-b2a2-a09b655de4a0) |
| 가게 삭제 결과 | ![image](https://github.com/user-attachments/assets/3e5ac2a9-141e-4812-a6a9-c4d2dc5fce26) |

## ⚠️ 주의 사항 (선택)

- 가게 상품 중간 테이블이 필요할 것 같습니다.
- 가게 단건 조회 ResponseDTO의 필드값으로 가게 상품 중간 테이블에 연결된 값을 토대로 한 Page 타입의 상품 조회 결과가 나와야 할 것 같습니다.

## ✅ 체크리스트

PR 작성자가 확인해야 할 항목입니다:

- [x] 코드가 정상적으로 동작하는지 확인했습니다.
- [x] 코드 리뷰어를 등록했습니다.
- [x] Labels를 등록했습니다.