### PR TITLE
feat(MFLP-52): Add a Store association to the Product entity and modify the related code

### DIFF
--- a/src/main/java/api/buyhood/domain/product/entity/Product.java
+++ b/src/main/java/api/buyhood/domain/product/entity/Product.java
@@ -1,12 +1,16 @@
 package api.buyhood.domain.product.entity;
 
+import api.buyhood.domain.store.entity.Store;
 import api.buyhood.global.common.entity.BaseTimeEntity;
 import api.buyhood.global.common.exception.InvalidRequestException;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -38,12 +42,17 @@ public class Product extends BaseTimeEntity {
 	@Column(nullable = false)
 	private Long stock;
 
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "store_id")
+	private Store store;
+
 	@Builder
-	public Product(String name, Long price, String description, Long stock) {
+	public Product(String name, Long price, String description, Long stock, Store store) {
 		this.name = name;
 		this.price = price;
 		this.description = description;
 		this.stock = stock;
+		this.store = store;
 	}
 
 	//재고 감소

--- a/src/main/java/api/buyhood/domain/product/repository/ProductRepository.java
+++ b/src/main/java/api/buyhood/domain/product/repository/ProductRepository.java
@@ -1,6 +1,7 @@
 package api.buyhood.domain.product.repository;
 
 import api.buyhood.domain.product.entity.Product;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -11,21 +12,28 @@ import org.springframework.data.repository.query.Param;
 public interface ProductRepository extends JpaRepository<Product, Long> {
 
 	@Query(
-		value = "select p from Product p where p.name like %:keyword% and p.deletedAt is null",
-		countQuery = "select count(p) from Product p where p.name like %:keyword% and p.deletedAt is null")
-	Page<Product> findActiveProductsByKeyword(@Param("keyword") String keyword, Pageable pageable);
+		value = "select p from Product p join p.store s where s.id = :storeId and p.name like %:keyword% and p.deletedAt is null",
+		countQuery = "select count(p) from Product p join p.store s where s.id = :storeId and p.name like %:keyword% and p.deletedAt is null")
+	Page<Product> findActiveProductsByStoreIdAndKeyword(
+		@Param("storeId") Long storeId,
+		@Param("keyword") String keyword,
+		Pageable pageable
+	);
 
-	@Query("select count(p) > 0 from Product p where p.name = :productName")
-	boolean existsByName(String productName);
+	@Query("select count(p) > 0 from Product p join p.store s where s.id = :storeId and p.name = :productName")
+	boolean existsByStoreIdAndProductName(@Param("storeId") Long storeId, @Param("productName") String productName);
 
-	@Query("select p from Product p where p.id = :productId and p.deletedAt is null")
-	Optional<Product> findActiveProductByIdAndDeletedAtIsNull(@Param("productId") Long productId);
+	@Query("select p from Product p join p.store s where s.id = :storeId and p.id = :productId and p.deletedAt is null")
+	Optional<Product> findActiveProductByStoreIdAndProductId(
+		@Param("storeId") Long storeId,
+		@Param("productId") Long productId
+	);
 
 	@Query(
-		value = "select p from Product p where p.deletedAt is null",
-		countQuery = "select count(p) from Product p where p.deletedAt is null")
-	Page<Product> findActiveProducts(Pageable pageable);
+		value = "select p from Product p join p.store s where s.id = :storeId and p.deletedAt is null",
+		countQuery = "select count(p) from Product p join p.store s where s.id = :storeId and p.deletedAt is null")
+	Page<Product> findActiveProductsByStoreId(@Param("storeId") Long storeId, Pageable pageable);
 
-	@Query("select p from Product p where p.id = :productId and p.deletedAt is null")
-	Optional<Product> findActiveProductById(Long productId);
+	@Query("select p from Product p join p.store s where s.id = :storeId and p.deletedAt is null")
+	List<Product> findActiveProductsByStoreId(Long storeId);
 }

--- a/src/main/java/api/buyhood/domain/store/dto/response/GetStoreRes.java
+++ b/src/main/java/api/buyhood/domain/store/dto/response/GetStoreRes.java
@@ -1,7 +1,9 @@
 package api.buyhood.domain.store.dto.response;
 
+import api.buyhood.domain.product.dto.response.GetProductRes;
 import api.buyhood.domain.store.entity.Store;
 import java.time.LocalTime;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -12,19 +14,21 @@ public class GetStoreRes {
 
 	private final Long storeId;
 	private final String storeName;
+	private final List<GetProductRes> productResList;
 	private final String address;
-	private final Long sellerId;
+	private final String sellerName;
 	private final boolean isDeliverable;
 	private final String description;
 	private final LocalTime openedAt;
 	private final LocalTime closedAt;
 
-	public static GetStoreRes of(Store store) {
+	public static GetStoreRes of(Store store, List<GetProductRes> productResList) {
 		return new GetStoreRes(
 			store.getId(),
 			store.getName(),
+			productResList,
 			store.getAddress(),
-			store.getSeller().getId(),
+			store.getSeller().getUsername(),
 			store.isDeliverable(),
 			store.getDescription(),
 			store.getOpenedAt(),

--- a/src/main/java/api/buyhood/domain/store/repository/StoreRepository.java
+++ b/src/main/java/api/buyhood/domain/store/repository/StoreRepository.java
@@ -12,6 +12,9 @@ public interface StoreRepository extends JpaRepository<Store, Long> {
 
 	boolean existsByName(String storeName);
 
+	@Query("select s from Store s where s.id = :storeId and s.deletedAt is null")
+	Optional<Store> findActiveStoreById(Long storeId);
+
 	@Query("select s from Store s inner join fetch s.seller where s.id = :storeId and s.deletedAt is null")
 	Optional<Store> findActiveStoreByIdFetchSeller(Long storeId);
 


### PR DESCRIPTION
## 📌 PR 요약

- `Product` 엔티티에 `Store` 연관 관계 추가 및 관련 코드 수정

## 🔗 관련 이슈

- MFLP-52

## 🛠️ 작업 내역

- `Product` 엔티티에 `Store` 연관 관계 추가
- `Product` 도메인 API의 URI 경로 변경
- 연관 관계 추가로 인한 관련 코드 수정

## 📸 스크린샷 (선택)

작업 결과를 스크린샷으로 첨부해주세요.

| 기능  | 스크린샷               |
|-----|--------------------|
| 가게 단건 조회 결과 1 | ![image](https://github.com/user-attachments/assets/a4abf927-01a7-450c-af24-0e078dc37fe3) |
| 가게 단건 조회 결과 2 | ![image](https://github.com/user-attachments/assets/6ac3f986-9865-4a32-a25d-95f458b4b5a4) |

## ⚠️ 주의 사항 (선택)

- 생각보다 짜잘하게 바뀐 부분이 많아서 일일히 전부 결과를 남기진 못했습니다.

## ✅ 체크리스트

PR 작성자가 확인해야 할 항목입니다:

- [x] 코드가 정상적으로 동작하는지 확인했습니다.
- [x] 코드 리뷰어를 등록했습니다.
- [x] Labels를 등록했습니다.