### PR TITLE
fix(MFLP-66): Remove `@Min` applied within the Category domain

### DIFF
--- a/src/main/java/api/buyhood/domain/product/entity/Category.java
+++ b/src/main/java/api/buyhood/domain/product/entity/Category.java
@@ -40,7 +40,6 @@ public class Category extends BaseTimeEntity {
 	private String name;
 
 	@Column(nullable = false)
-	@Min(0)
 	private int depth;
 
 	@ManyToOne(fetch = FetchType.LAZY)


### PR DESCRIPTION
## 📌 PR 요약

- 카테고리 도메인에 잘못 적용된 `@Min` 제거

## 🔗 관련 이슈

- MFLP-66

## 🛠️ 작업 내역

- 카테고리 도메인에 잘못 적용된 `@Min` 제거

## 📸 스크린샷 (선택)

작업 결과를 스크린샷으로 첨부해주세요.

| 기능  | 스크린샷               |
|-----|--------------------|
| 제거 전 | ![image](https://github.com/user-attachments/assets/e291ff8b-8281-49f0-a110-ff6ad95fda5d) |
| 제거 후 | ![image](https://github.com/user-attachments/assets/33270959-13c9-4640-82e8-5fda916e6b43) |


## ⚠️ 주의 사항 (선택)

- MVP 병합 전 추가해주세요.

## ✅ 체크리스트

PR 작성자가 확인해야 할 항목입니다:

- [x] 코드가 정상적으로 동작하는지 확인했습니다.
- [x] 코드 리뷰어를 등록했습니다.
- [x] Labels를 등록했습니다.