### PR TITLE
infra(INFRA-13~20) : deployment from AWS codedeploy && ssh

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,49 +1,62 @@
-name: CD - Deploy to EC2
+name: CD - Deploy via AWS CodeDeploy
 
 on:
   push:
     branches:
-      - develop
+      - develop   
+
+env:
+  AWS_REGION: ap-northeast-2                 
+  DEPLOYMENT_BUCKET: buyhood-deploy          
+  APPLICATION_NAME: BuyHood-Service          
+  DEPLOYMENT_GROUP: BuyHood-EC2-Deployment   
 
 jobs:
   deploy:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v3
+      - name: Checkout code
+        uses: actions/checkout@v4    
 
-    - name: Set up JDK 21
-      uses: actions/setup-java@v3
-      with:
-        distribution: 'temurin'
-        java-version: '21'
+      - name: Set up JDK 21 (Amazon Corretto)
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'corretto'
+          java-version: '21'        
 
-    - name: Save SSH key
-      run: |
-        mkdir -p ~/.ssh
-        echo "${{ secrets.EC2_KEY }}" > ~/.ssh/deploy_key.pem
-        chmod 600 ~/.ssh/deploy_key.pem
+      - name: Grant execute permission to Gradle wrapper
+        run: chmod +x ./gradlew       
 
-    - name: Grant execute permission to Gradle wrapper
-      run: chmod +x ./gradlew
+      - name: Build with Gradle
+        run: |
+          ./gradlew clean build -x test -Dspring.profiles.active=local
 
-    - name: Build with Gradle
-      run: ./gradlew clean build -x test -Dspring.profiles.active=local
+      - name: Prepare artifact for CodeDeploy
+        run: |
+          mkdir -p deploy
+          cp build/libs/*.jar deploy/                      
+          cp appspec.yml deploy/                            
+          if [ -d "./scripts" ]; then cp -r scripts deploy/; fi
+          cd deploy
+          zip -r ../buyhood_deploy_package.zip .              
 
-    - name: Copy JAR file to EC2
-      run: |
-        scp -i ~/.ssh/deploy_key.pem -o StrictHostKeyChecking=no \
-        build/libs/*.jar \
-        ${{ secrets.EC2_USER }}@${{ secrets.EC2_HOST }}:/home/${{ secrets.EC2_USER }}/app.jar
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v2      
+        with:
+          aws-access-key-id:  ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
 
-    - name: Deploy on EC2 via SSH
-      run: |
-        ssh -i ~/.ssh/deploy_key.pem -o StrictHostKeyChecking=no \
-        ${{ secrets.EC2_USER }}@${{ secrets.EC2_HOST }} << 'EOF'
-          echo "EC2 접속 성공"
-          pkill -f 'java -jar' || true
-          nohup java -jar /home/${{ secrets.EC2_USER }}/app.jar > app.log 2>&1 &
-          echo "JAR 실행 완료. 로그 보기:"
-          tail -n 10 app.log || echo "아직 로그 없음"
-        EOF
+      - name: Upload artifact to S3
+        run: |
+          aws s3 cp buyhood_deploy_package.zip \
+            s3://${{ env.DEPLOYMENT_BUCKET }}/buyhood_deploy_package.zip   
+
+      - name: Create CodeDeploy deployment
+        run: |
+          aws deploy create-deployment \
+            --application-name ${{ env.APPLICATION_NAME }} \
+            --deployment-group-name ${{ env.DEPLOYMENT_GROUP }} \
+            --s3-location bucket=${{ env.DEPLOYMENT_BUCKET }},key=buyhood_deploy_package.zip,bundleType=zip \
+            --file-exists-behavior OVERWRITE                 

--- a/appspec.yml
+++ b/appspec.yml
@@ -1,0 +1,5 @@
+version: 0.0
+os: linux
+files:
+  - source: /
+    destination: /home/ec2-user/app/deploy

--- a/build.gradle
+++ b/build.gradle
@@ -60,6 +60,11 @@ dependencies {
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 
-tasks.named('test') {
-	useJUnitPlatform()
+tasks.withType(org.gradle.api.tasks.testing.Test) {
+    useJUnitPlatform()
+
+    if (System.getenv("CI") == "true") {
+        systemProperty "spring.profiles.active", "ci"
+    }
+    // 로컬에서는 아무 프로파일도 강제하지 않으므로 application.properties(H2) 사용
 }


### PR DESCRIPTION
## 📌 PR 요약

- CI/CD 구성
- 기존 CI/CD 배포 방식을 SSH 기반 EC2 직접 복사(pseudo-SSH) → AWS CodeDeploy 방식으로 전환  
  (infra/INFRA-3-CD 브랜치에서 작업)

## 🔗 관련 이슈
- INFRA-13~20

## 🛠️ 작업 내역
- SSH 배포 스텝(SSH 키 저장, scp, ssh 접속 등) 전부 제거  
- cd.yml에 S3 업로드 및 aws deploy create-deployment 단계 추가  

## 📸 스크린샷 (선택)

작업 결과를 스크린샷으로 첨부해주세요.

| 기능  | 스크린샷               |
|-----|--------------------|
| PNG | ![스크린샷](사진을 넣어주세요) |

## ⚠️ 주의 사항 (선택)

- **배포 디렉터리 경로**  
  - appspec.yml에서 destination: /home/ec2-user/app/deploy 로 지정했으므로, 추후 스크립트가 경로를 잘 참조하는지 확인하세요.  
  - 예를 들어 start_server.sh에서 실행하는 JAR 경로(your-app.jar)가 /home/ec2-user/app/deploy/your-app.jar이어야 합니다.
  
## ✅ 체크리스트

PR 작성자가 확인해야 할 항목입니다:

- [x] 코드가 정상적으로 동작하는지 확인했습니다.
- [x] 코드 리뷰어를 등록했습니다.
- [x] Labels를 등록했습니다.