### PR TITLE
feat(MFLP-81): Dividing User Module & Implementing grant-SELLER and grant-ADMIN

### DIFF
--- a/buyhood-global-core/buyhood-global-common/src/main/java/api/buyhood/errorcode/UserErrorCode.java
+++ b/buyhood-global-core/buyhood-global-common/src/main/java/api/buyhood/errorcode/UserErrorCode.java
@@ -8,6 +8,9 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum UserErrorCode implements ErrorCode {
 	//에러코드 1200번대 사용예정
+	BUSINESS_NUMBER_DUPLICATED(1211, "이미 등록된 사업자 등록번호입니다.", HttpStatus.CONFLICT),
+	ALREADY_SELLER(1212, "이미 SELLER 권한이 있습니다.", HttpStatus.BAD_REQUEST),
+	BUSINESS_NUMBER_ALREADY_REGISTERED(1213, "이미 사업자 등록번호가 등록되어 있습니다.", HttpStatus.CONFLICT),
 	PASSWORD_SAME_AS_OLD(1204, "기존 비밀번호와 같습니다.", HttpStatus.BAD_REQUEST),
 	USER_INVALID_PASSWORD(1203, "비밀번호가 올바르지 않습니다.", HttpStatus.BAD_REQUEST),
 	USER_NOT_FOUND(1202, "해당 유저를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),

--- a/buyhood-global-core/buyhood-global-config/build.gradle
+++ b/buyhood-global-core/buyhood-global-config/build.gradle
@@ -1,46 +1,46 @@
 plugins {
-    id 'java'
+	id 'java'
 }
 
 group = 'api'
 version = '0.0.1-SNAPSHOT'
 
 repositories {
-    mavenCentral()
-    maven { url 'https://jitpack.io' }
+	mavenCentral()
+	maven { url 'https://jitpack.io' }
 }
 
 // 빌드 시 현재 모듈의 .jar 생성
 tasks.named("jar") {
-    enabled = true
+	enabled = true
 }
 
 tasks.named("bootJar") {
-    enabled = false
+	enabled = false
 }
 
 dependencies {
-    api project(':buyhood-global-core:buyhood-global-common')
-    
-    // spring data jpa
-    api 'org.springframework.boot:spring-boot-starter-data-jpa'
-    
-    // spring data redis
-    api 'org.springframework.boot:spring-boot-starter-data-redis'
-    
-    // spring security
-    api 'org.springframework.boot:spring-boot-starter-security'
-    
-    // jjwt
-    api 'io.jsonwebtoken:jjwt-api:0.12.6'
-    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
-    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
-
-    //portone
-    implementation 'com.github.iamport:iamport-rest-client-java:0.2.23'
-    implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
+	api project(':buyhood-global-core:buyhood-global-common')
+	
+	// spring data jpa
+	api 'org.springframework.boot:spring-boot-starter-data-jpa'
+	
+	// spring data redis
+	api 'org.springframework.boot:spring-boot-starter-data-redis'
+	
+	// spring security
+	api 'org.springframework.boot:spring-boot-starter-security'
+	
+	// jjwt
+	api 'io.jsonwebtoken:jjwt-api:0.12.6'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
+	
+	//portone
+	implementation 'com.github.iamport:iamport-rest-client-java:0.2.23'
+	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 }
 
 test {
-    useJUnitPlatform()
+	useJUnitPlatform()
 }

--- a/buyhood-user/build.gradle
+++ b/buyhood-user/build.gradle
@@ -15,6 +15,7 @@ java {
 
 repositories {
 	mavenCentral()
+	maven { url 'https://jitpack.io' }
 }
 
 dependencies {
@@ -23,6 +24,9 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+	
+	// spring validation
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	
 	// h2 database
 	runtimeOnly 'com.h2database:h2'

--- a/buyhood-user/src/main/java/api/buyhood/domain/user/BuyhoodDomainUserApplication.java
+++ b/buyhood-user/src/main/java/api/buyhood/domain/user/BuyhoodDomainUserApplication.java
@@ -3,7 +3,9 @@ package api.buyhood.domain.user;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
-@SpringBootApplication
+@SpringBootApplication(scanBasePackages = {
+	"api.buyhood"
+})
 public class BuyhoodDomainUserApplication {
 
 	public static void main(String[] args) {

--- a/buyhood-user/src/main/java/api/buyhood/domain/user/controller/UserController.java
+++ b/buyhood-user/src/main/java/api/buyhood/domain/user/controller/UserController.java
@@ -1,0 +1,92 @@
+package api.buyhood.domain.user.controller;
+
+import api.buyhood.domain.user.dto.req.ChangeSellerRoleReq;
+import api.buyhood.domain.user.dto.req.ChangeUserPasswordReq;
+import api.buyhood.domain.user.dto.req.DeleteUserReq;
+import api.buyhood.domain.user.dto.req.PatchUserReq;
+import api.buyhood.domain.user.dto.res.GetUserRes;
+import api.buyhood.domain.user.dto.res.PatchUserRes;
+import api.buyhood.domain.user.service.UserService;
+import api.buyhood.dto.Response;
+import api.buyhood.security.AuthUser;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class UserController {
+
+	private final UserService userService;
+
+	//단건 조회
+	@GetMapping("/v1/users/{userId}")
+	public Response<GetUserRes> getUser(@PathVariable Long userId) {
+		GetUserRes response = userService.getUser(userId);
+
+		return Response.ok(response);
+	}
+
+	//다건 조회
+	@GetMapping("v1/users")
+	public Response<Page<GetUserRes>> getUsers(
+		@RequestParam(defaultValue = "0") int page,
+		@RequestParam(defaultValue = "10") int size) {
+		Page<GetUserRes> response = userService.getAllUsers(page, size);
+
+		return Response.ok(response);
+	}
+
+	//비밀번호 변경
+	@PatchMapping("/v1/users/password")
+	public Response<String> changePassword(
+		@AuthenticationPrincipal AuthUser authUser,
+		@RequestBody @Valid ChangeUserPasswordReq req) {
+		userService.changePassword(authUser, req);
+
+		return Response.ok("비밀번호 변경에 성공했습니다.");
+	}
+
+	//유저 정보 변경(로그인한 유저 전용)
+	@PatchMapping("/v1/users")
+	public Response<PatchUserRes> patchUser(
+		@AuthenticationPrincipal AuthUser authUser,
+		@RequestBody @Valid PatchUserReq req
+	) {
+		PatchUserRes patchUserRes = userService.patchUser(authUser, req);
+		return Response.ok(patchUserRes);
+	}
+
+	//유저 삭제
+	@DeleteMapping("/v1/users")
+	public Response<String> deleteUser(
+		@AuthenticationPrincipal AuthUser authUser,
+		@RequestBody @Valid DeleteUserReq req) {
+		userService.deleteUser(authUser, req);
+
+		return Response.ok("회원탈퇴에 성공했습니다.");
+	}
+
+	@PatchMapping("/v1/users/{userId}/grant-seller")
+	public Response<String> grantSeller(@PathVariable Long userId, ChangeSellerRoleReq req) {
+		userService.grantSeller(userId, req);
+		return Response.ok("SELLER 권한이 부여되었습니다. 재로그인 해주세요");
+	}
+
+	@PatchMapping("/v1/users/{userId}/grant-admin")
+	public Response<String> grantAdmin(@PathVariable Long userId) {
+		userService.grantAdmin(userId);
+		return Response.ok("ADMIN 권한이 부여되었습니다. 재로그인 해주세요");
+	}
+
+}

--- a/buyhood-user/src/main/java/api/buyhood/domain/user/dto/req/ChangeSellerRoleReq.java
+++ b/buyhood-user/src/main/java/api/buyhood/domain/user/dto/req/ChangeSellerRoleReq.java
@@ -1,0 +1,15 @@
+package api.buyhood.domain.user.dto.req;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ChangeSellerRoleReq {
+
+	@NotBlank(message = "사업자등록 번호를 기입해주세요.")
+	private String businessNumber;
+}

--- a/buyhood-user/src/main/java/api/buyhood/domain/user/dto/req/ChangeUserPasswordReq.java
+++ b/buyhood-user/src/main/java/api/buyhood/domain/user/dto/req/ChangeUserPasswordReq.java
@@ -1,0 +1,22 @@
+package api.buyhood.domain.user.dto.req;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class ChangeUserPasswordReq {
+
+	@NotBlank(message = "기존 비밀번호는 필수 입력값입니다.")
+	private String oldPassword;
+	@NotBlank(message = "새 비밀번호는 필수 입력값입니다.")
+	@Pattern(
+		regexp = "^(?=.*[A-Z])(?=.*\\d).{8,}$",
+		message = "비밀번호는 8자 이상, 숫자와 대문자를 포함해야 합니다."
+	)
+	private String newPassword;
+}

--- a/buyhood-user/src/main/java/api/buyhood/domain/user/dto/req/DeleteUserReq.java
+++ b/buyhood-user/src/main/java/api/buyhood/domain/user/dto/req/DeleteUserReq.java
@@ -1,0 +1,16 @@
+package api.buyhood.domain.user.dto.req;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class DeleteUserReq {
+
+	@NotBlank(message = "비밀번호를 입력하세요")
+	private String password;
+
+}

--- a/buyhood-user/src/main/java/api/buyhood/domain/user/dto/req/PatchUserReq.java
+++ b/buyhood-user/src/main/java/api/buyhood/domain/user/dto/req/PatchUserReq.java
@@ -1,0 +1,15 @@
+package api.buyhood.domain.user.dto.req;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class PatchUserReq {
+
+	private String username;
+	private String address;
+}
+

--- a/buyhood-user/src/main/java/api/buyhood/domain/user/dto/res/GetUserRes.java
+++ b/buyhood-user/src/main/java/api/buyhood/domain/user/dto/res/GetUserRes.java
@@ -1,0 +1,26 @@
+package api.buyhood.domain.user.dto.res;
+
+import api.buyhood.domain.user.entity.User;
+import api.buyhood.enums.UserRole;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class GetUserRes {
+
+	private final String username;
+	private final String email;
+
+	private final UserRole role;
+	private final String address;
+
+	public static GetUserRes of(User user) {
+		return new GetUserRes(
+			user.getUsername(),
+			user.getEmail(),
+			user.getRole(),
+			user.getAddress()
+		);
+	}
+}

--- a/buyhood-user/src/main/java/api/buyhood/domain/user/dto/res/PatchUserRes.java
+++ b/buyhood-user/src/main/java/api/buyhood/domain/user/dto/res/PatchUserRes.java
@@ -1,0 +1,19 @@
+package api.buyhood.domain.user.dto.res;
+
+import api.buyhood.domain.user.entity.User;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class PatchUserRes {
+
+	private final String username;
+	private final String address;
+
+	public static PatchUserRes of(User user) {
+		return new PatchUserRes(
+			user.getUsername(),
+			user.getAddress());
+	}
+}

--- a/buyhood-user/src/main/java/api/buyhood/domain/user/entity/User.java
+++ b/buyhood-user/src/main/java/api/buyhood/domain/user/entity/User.java
@@ -1,6 +1,5 @@
 package api.buyhood.domain.user.entity;
 
-
 import api.buyhood.entity.BaseTimeEntity;
 import api.buyhood.enums.UserRole;
 import jakarta.persistence.Column;
@@ -46,6 +45,9 @@ public class User extends BaseTimeEntity {
 	@Column(nullable = false)
 	private String address;
 
+	@Column(unique = true)
+	private String businessNumber;
+
 	@Builder
 	public User(String username, String email, String password, String address, String phoneNumber) {
 		this.username = username;
@@ -71,5 +73,13 @@ public class User extends BaseTimeEntity {
 		if (address != null) {
 			this.address = address;
 		}
+	}
+
+	public void changeRole(UserRole newRole) {
+		this.role = newRole;
+	}
+
+	public void registerBusinessNumber(String businessNumber) {
+		this.businessNumber = businessNumber;
 	}
 }

--- a/buyhood-user/src/main/java/api/buyhood/domain/user/repository/UserRepository.java
+++ b/buyhood-user/src/main/java/api/buyhood/domain/user/repository/UserRepository.java
@@ -18,4 +18,5 @@ public interface UserRepository extends JpaRepository<User, Long> {
 	@Query("SELECT u FROM User u WHERE u.deletedAt IS NULL ")
 	Page<User> findAllActiveUsers(Pageable pageable);
 
+	boolean existsByBusinessNumber(String businessNumber);
 }

--- a/buyhood-user/src/main/java/api/buyhood/domain/user/service/UserService.java
+++ b/buyhood-user/src/main/java/api/buyhood/domain/user/service/UserService.java
@@ -1,0 +1,114 @@
+package api.buyhood.domain.user.service;
+
+import api.buyhood.domain.user.dto.req.ChangeSellerRoleReq;
+import api.buyhood.domain.user.dto.req.ChangeUserPasswordReq;
+import api.buyhood.domain.user.dto.req.DeleteUserReq;
+import api.buyhood.domain.user.dto.req.PatchUserReq;
+import api.buyhood.domain.user.dto.res.GetUserRes;
+import api.buyhood.domain.user.dto.res.PatchUserRes;
+import api.buyhood.domain.user.entity.User;
+import api.buyhood.domain.user.repository.UserRepository;
+import api.buyhood.enums.UserRole;
+import api.buyhood.exception.InvalidRequestException;
+import api.buyhood.exception.NotFoundException;
+import api.buyhood.security.AuthUser;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import static api.buyhood.errorcode.UserErrorCode.ALREADY_SELLER;
+import static api.buyhood.errorcode.UserErrorCode.BUSINESS_NUMBER_ALREADY_REGISTERED;
+import static api.buyhood.errorcode.UserErrorCode.PASSWORD_SAME_AS_OLD;
+import static api.buyhood.errorcode.UserErrorCode.USER_INVALID_PASSWORD;
+import static api.buyhood.errorcode.UserErrorCode.USER_NOT_FOUND;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+	private final UserRepository userRepository;
+	private final PasswordEncoder passwordEncoder;
+
+	//단건 조회
+	@Transactional(readOnly = true)
+	public GetUserRes getUser(Long id) {
+		User user = userRepository.findById(id)
+			.orElseThrow(() -> new NotFoundException(USER_NOT_FOUND));
+
+		return GetUserRes.of(user);
+	}
+
+	//다건 조회
+	@Transactional(readOnly = true)
+	public Page<GetUserRes> getAllUsers(int page, int size) {
+		Page<User> users = userRepository.findAllActiveUsers(PageRequest.of(page, size));
+		return users.map(GetUserRes::of);
+	}
+
+	//비밀번호 변경
+	@Transactional
+	public void changePassword(AuthUser authUser, ChangeUserPasswordReq changeUserPasswordReq) {
+		User user = userRepository.findByEmail(authUser.getEmail())
+			.orElseThrow(() -> new NotFoundException(USER_NOT_FOUND));
+
+		validatePassword(changeUserPasswordReq.getOldPassword(), user.getPassword());
+		if (passwordEncoder.matches(changeUserPasswordReq.getNewPassword(), user.getPassword())) {
+			throw new InvalidRequestException(PASSWORD_SAME_AS_OLD);
+		}
+		user.changePassword(passwordEncoder.encode(changeUserPasswordReq.getNewPassword()));
+	}
+
+	//회원 정보 변경
+	@Transactional
+	public PatchUserRes patchUser(AuthUser authUser, PatchUserReq patchUserReq) {
+		User user = userRepository.findByEmail(authUser.getEmail())
+			.orElseThrow(() -> new NotFoundException(USER_NOT_FOUND));
+
+		user.patchUser(patchUserReq.getUsername(), patchUserReq.getAddress());
+
+		return PatchUserRes.of(user);
+	}
+
+	//회원탈퇴
+	@Transactional
+	public void deleteUser(AuthUser authUser, DeleteUserReq deleteUserReq) {
+		User findUser = userRepository.findByEmail(authUser.getEmail())
+			.orElseThrow(() -> new NotFoundException(USER_NOT_FOUND));
+
+		validatePassword(deleteUserReq.getPassword(), findUser.getPassword());
+		findUser.deleteUser();
+	}
+
+	private void validatePassword(String rawPassword, String encodedPassword) {
+		if (!passwordEncoder.matches(rawPassword, encodedPassword)) {
+			throw new InvalidRequestException(USER_INVALID_PASSWORD);
+		}
+	}
+
+	@Transactional
+	public void grantSeller(Long userId, ChangeSellerRoleReq req) {
+		User user = userRepository.findById(userId)
+			.orElseThrow(() -> new NotFoundException(USER_NOT_FOUND));
+
+		if (user.getRole() == UserRole.SELLER) {
+			throw new InvalidRequestException(ALREADY_SELLER);
+		}
+		// 다수의 사업자등록번호 입력방지
+		if (user.getBusinessNumber() != null) {
+			throw new InvalidRequestException(BUSINESS_NUMBER_ALREADY_REGISTERED);
+		}
+
+		user.registerBusinessNumber(req.getBusinessNumber());
+		user.changeRole(UserRole.SELLER);
+	}
+
+	@Transactional
+	public void grantAdmin(Long userId) {
+		User user = userRepository.findById(userId)
+			.orElseThrow(() -> new NotFoundException(USER_NOT_FOUND));
+		user.changeRole(UserRole.ADMIN);
+	}
+}


### PR DESCRIPTION
## 📌 PR 요약

- 유저 모듈 분리
- 관리자 권한 셀러 권한 부여 API만듦

## 🔗 관련 이슈

MFLP-81

## 🛠️ 작업 내역

- 작업 내역을 bullet으로 작성해주세요.
    - PR요약이랑 같음

## 📸 스크린샷 (선택)

작업 결과를 스크린샷으로 첨부해주세요.

| 기능  | 스크린샷               |
|-----|--------------------|
| 셀러성공|![셀러권한부여성공](https://github.com/user-attachments/assets/4ee619cd-a6c7-428d-a418-9e3ceb435b0b)|
| 어드민성공|![어드민권한부여](https://github.com/user-attachments/assets/26ba651b-e412-4ca7-9c4a-24dee74bf67e)|



## ⚠️ 주의 사항 (선택)

리뷰어가 알아야 할 중요한 사항이나 주의할 점을 작성해주세요.

권한 부여 후 재로그인 해야합니다(토큰값떄문에)

## ✅ 체크리스트

PR 작성자가 확인해야 할 항목입니다:

- [X] 코드가 정상적으로 동작하는지 확인했습니다.
- [X] 코드 리뷰어를 등록했습니다.
- [X] Labels를 등록했습니다.