### PR TITLE
feat(MFLP-79): Separate product domain modules

### DIFF
--- a/buyhood-category/buyhood-product-category/src/main/java/api/buyhood/productcategory/controller/InternalProductCategoryController.java
+++ b/buyhood-category/buyhood-product-category/src/main/java/api/buyhood/productcategory/controller/InternalProductCategoryController.java
@@ -1,0 +1,35 @@
+package api.buyhood.productcategory.controller;
+
+import api.buyhood.dto.productcategory.ProductCategoryFeignDto;
+import api.buyhood.productcategory.service.InternalProductCategoryService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/internal")
+public class InternalProductCategoryController {
+
+	private final InternalProductCategoryService internalProductCategoryService;
+
+	@GetMapping("/v1/product-categories/exists")
+	public Boolean existsByIds(@RequestParam List<Long> categoryIds) {
+		return internalProductCategoryService.existsByIds(categoryIds);
+	}
+
+	@GetMapping("/v1/product-categories/{id}/exists")
+	public Boolean existsById(@PathVariable("id") Long categoryId) {
+		return internalProductCategoryService.existsById(categoryId);
+	}
+
+	@GetMapping("/v1/product-categories/{id}")
+	public ProductCategoryFeignDto getCategoryOrElseThrow(@PathVariable("id") Long categoryId) {
+		return internalProductCategoryService.getCategoryOrElseThrow(categoryId);
+	}
+
+}

--- a/buyhood-category/buyhood-product-category/src/main/java/api/buyhood/productcategory/repository/InternalProductCategoryRepository.java
+++ b/buyhood-category/buyhood-product-category/src/main/java/api/buyhood/productcategory/repository/InternalProductCategoryRepository.java
@@ -1,0 +1,8 @@
+package api.buyhood.productcategory.repository;
+
+import api.buyhood.productcategory.entity.ProductCategory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface InternalProductCategoryRepository extends JpaRepository<ProductCategory, Long> {
+
+}

--- a/buyhood-category/buyhood-product-category/src/main/java/api/buyhood/productcategory/service/InternalProductCategoryService.java
+++ b/buyhood-category/buyhood-product-category/src/main/java/api/buyhood/productcategory/service/InternalProductCategoryService.java
@@ -1,0 +1,69 @@
+package api.buyhood.productcategory.service;
+
+import api.buyhood.dto.productcategory.ProductCategoryFeignDto;
+import api.buyhood.errorcode.CategoryErrorCode;
+import api.buyhood.exception.InvalidRequestException;
+import api.buyhood.exception.NotFoundException;
+import api.buyhood.productcategory.entity.ProductCategory;
+import api.buyhood.productcategory.repository.InternalProductCategoryRepository;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class InternalProductCategoryService {
+
+	private final InternalProductCategoryRepository internalProductCategoryRepository;
+
+	@Transactional(readOnly = true)
+	public ProductCategoryFeignDto getCategoryOrElseThrow(Long categoryProductId) {
+		ProductCategory getProductCategory = internalProductCategoryRepository.findById(categoryProductId)
+			.orElseThrow(() -> new NotFoundException(CategoryErrorCode.CATEGORY_NOT_FOUND));
+
+		Long parentId = null;
+		List<Long> childrenIds = new ArrayList<>();
+
+		if (getProductCategory.getParent() != null) {
+			parentId = getProductCategory.getParent().getId();
+		}
+
+		if (!getProductCategory.getChildren().isEmpty()) {
+			for (ProductCategory child : getProductCategory.getChildren()) {
+				childrenIds.add(child.getId());
+			}
+		}
+
+		return new ProductCategoryFeignDto(
+			getProductCategory.getId(),
+			getProductCategory.getName(),
+			getProductCategory.getDepth(),
+			parentId,
+			childrenIds
+		);
+	}
+
+	@Transactional(readOnly = true)
+	public Boolean existsById(Long categoryProductId) {
+		return internalProductCategoryRepository.existsById(categoryProductId);
+	}
+
+	@Transactional(readOnly = true)
+	public Boolean existsByIds(List<Long> categoryProductIds) {
+		boolean existsFlag = true;
+
+		for (Long categoryProductId : categoryProductIds) {
+			if (!internalProductCategoryRepository.existsById(categoryProductId)) {
+				existsFlag = false;
+			}
+		}
+
+		if (existsFlag) {
+			throw new InvalidRequestException(CategoryErrorCode.CATEGORY_NOT_FOUND);
+		}
+
+		return existsFlag;
+	}
+}

--- a/buyhood-global-core/buyhood-global-common/src/main/java/api/buyhood/errorcode/CommonErrorCode.java
+++ b/buyhood-global-core/buyhood-global-common/src/main/java/api/buyhood/errorcode/CommonErrorCode.java
@@ -10,7 +10,8 @@ public enum CommonErrorCode implements ErrorCode {
 	//에러코드 4100번대
 	JSON_PARSING_FAILED(4101, "JSON 파싱 실패", HttpStatus.INTERNAL_SERVER_ERROR),
 	REDIS_SERIALIZE_FAILED(4102, "Redis 정보 직렬화 실패", HttpStatus.INTERNAL_SERVER_ERROR),
-	INVALID_TIME_FORMAT(4103, "잘못된 시간 문자열 값입니다.", HttpStatus.BAD_REQUEST);
+	INVALID_TIME_FORMAT(4103, "잘못된 시간 문자열 값입니다.", HttpStatus.BAD_REQUEST),
+	NOT_DEFINED_FEIGN_EXCEPTION(4151, "정의되지 않은 FeignClient 예외가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR);
 
 	private final int code;
 	private final String message;

--- a/buyhood-global-core/buyhood-global-common/src/main/java/api/buyhood/exception/ServerException.java
+++ b/buyhood-global-core/buyhood-global-common/src/main/java/api/buyhood/exception/ServerException.java
@@ -1,0 +1,10 @@
+package api.buyhood.exception;
+
+import api.buyhood.errorcode.ErrorCode;
+
+public class ServerException extends BaseException {
+
+	public ServerException(ErrorCode errorCode) {
+		super(errorCode);
+	}
+}

--- a/buyhood-global-core/buyhood-global-feign/src/main/java/api/buyhood/client/ProductCategoryClient.java
+++ b/buyhood-global-core/buyhood-global-feign/src/main/java/api/buyhood/client/ProductCategoryClient.java
@@ -1,0 +1,19 @@
+package api.buyhood.client;
+
+import api.buyhood.dto.productcategory.ProductCategoryFeignDto;
+import java.util.List;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+
+public interface ProductCategoryClient {
+
+	@GetMapping("/internal/v1/product-categories/exists")
+	Boolean existsByIds(@RequestParam List<Long> categoryIds);
+
+	@GetMapping("/internal/v1/product-categories/{id}/exists")
+	Boolean existsById(@PathVariable Long id);
+
+	@GetMapping("/internal/v1/product-categories/{id}")
+	ProductCategoryFeignDto getCategoryOrElseThrow(@PathVariable Long id);
+}

--- a/buyhood-global-core/buyhood-global-feign/src/main/java/api/buyhood/client/StoreClient.java
+++ b/buyhood-global-core/buyhood-global-feign/src/main/java/api/buyhood/client/StoreClient.java
@@ -1,0 +1,14 @@
+package api.buyhood.client;
+
+import api.buyhood.dto.store.StoreFeignDto;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+public interface StoreClient {
+
+	@GetMapping("/internal/v1/stores/{id}")
+	StoreFeignDto getStoreOrElseThrow(@PathVariable Long id);
+
+	@GetMapping("/internal/v1/stores/{id}/exists")
+	Boolean existsById(@PathVariable Long id);
+}

--- a/buyhood-global-core/buyhood-global-feign/src/main/java/api/buyhood/client/UserClient.java
+++ b/buyhood-global-core/buyhood-global-feign/src/main/java/api/buyhood/client/UserClient.java
@@ -10,8 +10,9 @@ public interface UserClient {
 	Boolean existsById(@PathVariable Long userId);
 
 	@GetMapping("/internal/v1/sellers/{sellerId}")
-	UserFeignDto getSellerResOrElseThrow(@PathVariable Long sellerId);
+	UserFeignDto getRoleSellerOrElseThrow(@PathVariable Long sellerId);
 
 	@GetMapping("/internal/v1/users/{userId}")
-	UserFeignDto getUserResOrElseThrow(@PathVariable Long userId);
+	UserFeignDto getRoleUserOrElseThrow(@PathVariable Long userId);
+	
 }

--- a/buyhood-global-core/buyhood-global-feign/src/main/java/api/buyhood/dto/productcategory/ProductCategoryFeignDto.java
+++ b/buyhood-global-core/buyhood-global-feign/src/main/java/api/buyhood/dto/productcategory/ProductCategoryFeignDto.java
@@ -1,0 +1,20 @@
+package api.buyhood.dto.productcategory;
+
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class ProductCategoryFeignDto {
+
+	private Long categoryId;
+	private String categoryName;
+	private int depth;
+	private Long parentId;
+	private List<Long> childrenIds;
+	
+}

--- a/buyhood-global-core/buyhood-global-feign/src/main/java/api/buyhood/dto/store/StoreFeignDto.java
+++ b/buyhood-global-core/buyhood-global-feign/src/main/java/api/buyhood/dto/store/StoreFeignDto.java
@@ -1,0 +1,17 @@
+package api.buyhood.dto.store;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class StoreFeignDto {
+
+	private Long storeId;
+	private String storeName;
+	private Long sellerId;
+
+}

--- a/buyhood-product/src/main/java/api/buyhood/product/BuyHoodProductApplication.java
+++ b/buyhood-product/src/main/java/api/buyhood/product/BuyHoodProductApplication.java
@@ -2,7 +2,9 @@ package api.buyhood.product;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 
+@EnableFeignClients(basePackages = {"api.buyhood.product.client"})
 @SpringBootApplication
 public class BuyHoodProductApplication {
 

--- a/buyhood-product/src/main/java/api/buyhood/product/client/ProductCategoryFeignClient.java
+++ b/buyhood-product/src/main/java/api/buyhood/product/client/ProductCategoryFeignClient.java
@@ -1,0 +1,14 @@
+package api.buyhood.product.client;
+
+import api.buyhood.client.ProductCategoryClient;
+import api.buyhood.config.FeignClientConfig;
+import org.springframework.cloud.openfeign.FeignClient;
+
+@FeignClient(
+	name = "productCategoryFeignClient",
+	url = "${product.category.url}",
+	configuration = FeignClientConfig.class
+)
+public interface ProductCategoryFeignClient extends ProductCategoryClient {
+
+}

--- a/buyhood-product/src/main/java/api/buyhood/product/client/StoreFeignClient.java
+++ b/buyhood-product/src/main/java/api/buyhood/product/client/StoreFeignClient.java
@@ -1,0 +1,14 @@
+package api.buyhood.product.client;
+
+import api.buyhood.client.StoreClient;
+import api.buyhood.config.FeignClientConfig;
+import org.springframework.cloud.openfeign.FeignClient;
+
+@FeignClient(
+	name = "storeFeignClient",
+	url = "${store.url}",
+	configuration = FeignClientConfig.class
+)
+public interface StoreFeignClient extends StoreClient {
+
+}

--- a/buyhood-product/src/main/java/api/buyhood/product/client/UserFeignClient.java
+++ b/buyhood-product/src/main/java/api/buyhood/product/client/UserFeignClient.java
@@ -1,0 +1,14 @@
+package api.buyhood.product.client;
+
+import api.buyhood.client.UserClient;
+import api.buyhood.config.FeignClientConfig;
+import org.springframework.cloud.openfeign.FeignClient;
+
+@FeignClient(
+	name = "userFeignClient",
+	url = "${user.url}",
+	configuration = FeignClientConfig.class
+)
+public interface UserFeignClient extends UserClient {
+
+}

--- a/buyhood-product/src/main/java/api/buyhood/product/dto/request/PatchProductReq.java
+++ b/buyhood-product/src/main/java/api/buyhood/product/dto/request/PatchProductReq.java
@@ -1,0 +1,21 @@
+package api.buyhood.product.dto.request;
+
+import jakarta.validation.constraints.Min;
+import java.util.List;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class PatchProductReq {
+
+	private final String productName;
+
+	@Min(0)
+	private final Long price;
+
+	@Min(0)
+	private final Long stock;
+	private final List<Long> categoryIds;
+	private final String description;
+}

--- a/buyhood-product/src/main/java/api/buyhood/product/dto/request/RegisterProductReq.java
+++ b/buyhood-product/src/main/java/api/buyhood/product/dto/request/RegisterProductReq.java
@@ -1,0 +1,28 @@
+package api.buyhood.product.dto.request;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.util.List;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class RegisterProductReq {
+
+	@NotBlank(message = "상품 이름은 공백일 수 없습니다.")
+	private final String productName;
+
+	@NotNull(message = "상품 가격은 공백일 수 없습니다.")
+	@Min(value = 0, message = "상품 가격은 0보다 작을 수 없습니다.")
+	private final Long price;
+
+	@NotNull(message = "상품 개수는 공백일 수 없습니다.")
+	@Min(value = 0, message = "상품 개수는 0보다 작을 수 없습니다.")
+	private final Long stock;
+
+	private final List<Long> categoryIdList;
+	private final String description;
+
+}

--- a/buyhood-product/src/main/java/api/buyhood/product/dto/response/GetProductRes.java
+++ b/buyhood-product/src/main/java/api/buyhood/product/dto/response/GetProductRes.java
@@ -1,0 +1,30 @@
+package api.buyhood.product.dto.response;
+
+import api.buyhood.product.entity.Product;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public class GetProductRes {
+
+	private final Long productId;
+	private final String productName;
+	private final Long price;
+	private final List<String> categoryNameList;
+	private final String description;
+	private final Long stock;
+
+	public static GetProductRes of(Product product, List<String> categoryNameList) {
+		return new GetProductRes(
+			product.getId(),
+			product.getName(),
+			product.getPrice(),
+			categoryNameList,
+			product.getDescription(),
+			product.getStock()
+		);
+	}
+}

--- a/buyhood-product/src/main/java/api/buyhood/product/dto/response/PageProductRes.java
+++ b/buyhood-product/src/main/java/api/buyhood/product/dto/response/PageProductRes.java
@@ -1,0 +1,32 @@
+package api.buyhood.product.dto.response;
+
+import api.buyhood.product.entity.Product;
+import java.util.List;
+import java.util.Map;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public class PageProductRes {
+
+	private final Long productId;
+	private final String productName;
+	private final Long price;
+	private final List<String> categoryNameList;
+	private final Long stock;
+
+	public static Page<PageProductRes> of(Page<Product> productPage, Map<Long, List<String>> categoryNameMap) {
+		return productPage.map(product ->
+			new PageProductRes(
+				product.getId(),
+				product.getName(),
+				product.getPrice(),
+				categoryNameMap.getOrDefault(product.getId(), List.of()),
+				product.getStock()
+			)
+		);
+	}
+}

--- a/buyhood-product/src/main/java/api/buyhood/product/dto/response/RegisterProductRes.java
+++ b/buyhood-product/src/main/java/api/buyhood/product/dto/response/RegisterProductRes.java
@@ -1,0 +1,30 @@
+package api.buyhood.product.dto.response;
+
+import api.buyhood.product.entity.Product;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public class RegisterProductRes {
+
+	private final Long productId;
+	private final String productName;
+	private final Long price;
+	private final Long stock;
+	private final List<String> categoryNameList;
+	private final String description;
+
+	public static RegisterProductRes of(Product product, List<String> categoryNameList) {
+		return new RegisterProductRes(
+			product.getId(),
+			product.getName(),
+			product.getPrice(),
+			product.getStock(),
+			categoryNameList,
+			product.getDescription()
+		);
+	}
+}

--- a/buyhood-product/src/main/java/api/buyhood/product/entity/Product.java
+++ b/buyhood-product/src/main/java/api/buyhood/product/entity/Product.java
@@ -1,0 +1,73 @@
+package api.buyhood.product.entity;
+
+import api.buyhood.entity.BaseTimeEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "products")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Product extends BaseTimeEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(nullable = false)
+	private Long id;
+
+	@Column(nullable = false)
+	private String name;
+
+	@Column(nullable = false)
+	private Long price;
+
+	@Column
+	private String description;
+
+	@Column(nullable = false)
+	private Long stock;
+
+	@Column(nullable = false)
+	private Long storeId;
+
+	@Builder
+	public Product(String name, Long price, String description, Long stock, Long storeId) {
+		this.name = name;
+		this.price = price;
+		this.description = description;
+		this.stock = stock;
+		this.storeId = storeId;
+	}
+
+	public void decreaseStock(int quantity) {
+		this.stock -= quantity;
+	}
+
+	public void rollBackStock(int quantity) {
+		this.stock += quantity;
+	}
+
+	public void patchName(String productName) {
+		this.name = productName;
+	}
+
+	public void patchPrice(Long price) {
+		this.price = price;
+	}
+
+	public void patchDescription(String description) {
+		this.description = description;
+	}
+
+	public void patchStock(Long stock) {
+		this.stock = stock;
+	}
+}

--- a/buyhood-product/src/main/java/api/buyhood/product/entity/ProductCategoryMapping.java
+++ b/buyhood-product/src/main/java/api/buyhood/product/entity/ProductCategoryMapping.java
@@ -1,0 +1,37 @@
+package api.buyhood.product.entity;
+
+import api.buyhood.entity.BaseTimeEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "product_categories_mapping")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ProductCategoryMapping extends BaseTimeEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(nullable = false)
+	private Long id;
+
+	@Column(nullable = false)
+	private Long productId;
+
+	@Column(nullable = false)
+	private Long categoryId;
+
+	@Builder
+	public ProductCategoryMapping(Long productId, Long categoryId) {
+		this.productId = productId;
+		this.categoryId = categoryId;
+	}
+}

--- a/buyhood-product/src/main/java/api/buyhood/product/repository/ProductCategoryMappingRepository.java
+++ b/buyhood-product/src/main/java/api/buyhood/product/repository/ProductCategoryMappingRepository.java
@@ -1,0 +1,14 @@
+package api.buyhood.product.repository;
+
+import api.buyhood.product.entity.ProductCategoryMapping;
+import feign.Param;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProductCategoryMappingRepository extends JpaRepository<ProductCategoryMapping, Long> {
+
+	void deleteByProductId(Long productId);
+
+	boolean existsByProductIdAndCategoryId(@Param("productId") Long productId, @Param("categoryId") Long categoryId);
+
+	void deleteByProductIdAndCategoryId(@Param("productId") Long productId, @Param("categoryId") Long categoryId);
+}

--- a/buyhood-product/src/main/java/api/buyhood/product/repository/ProductRepository.java
+++ b/buyhood-product/src/main/java/api/buyhood/product/repository/ProductRepository.java
@@ -1,0 +1,23 @@
+package api.buyhood.product.repository;
+
+import api.buyhood.product.entity.Product;
+import feign.Param;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+public interface ProductRepository extends JpaRepository<Product, Long> {
+
+	@Query("select p from Product p where p.storeId = :storeId and p.deletedAt is null")
+	List<Product> findActiveProductsByStoreId(Long storeId);
+
+	@Query("select count(p) > 0 from Product p where p.id = :id and lower(p.name) = lower(:name)")
+	boolean existsByStoreIdAndProductName(@Param("id") Long storeId, @Param("name") String productName);
+
+	@Query("select p from Product p where p.id = :productId and p.deletedAt is null")
+	Optional<Product> findActiveProductByProductId(Long productId);
+
+	@Query("select count(p) > 0 from Product p where p.id = :productId and p.deletedAt is null")
+	boolean existsActiveProductById(Long productId);
+}

--- a/buyhood-product/src/main/java/api/buyhood/product/service/ProductService.java
+++ b/buyhood-product/src/main/java/api/buyhood/product/service/ProductService.java
@@ -1,0 +1,239 @@
+package api.buyhood.product.service;
+
+import api.buyhood.dto.productcategory.ProductCategoryFeignDto;
+import api.buyhood.dto.store.StoreFeignDto;
+import api.buyhood.dto.user.UserFeignDto;
+import api.buyhood.errorcode.CategoryErrorCode;
+import api.buyhood.errorcode.CommonErrorCode;
+import api.buyhood.errorcode.ProductErrorCode;
+import api.buyhood.errorcode.StoreErrorCode;
+import api.buyhood.errorcode.UserErrorCode;
+import api.buyhood.exception.ConflictException;
+import api.buyhood.exception.InvalidRequestException;
+import api.buyhood.exception.NotFoundException;
+import api.buyhood.exception.ServerException;
+import api.buyhood.product.client.ProductCategoryFeignClient;
+import api.buyhood.product.client.StoreFeignClient;
+import api.buyhood.product.client.UserFeignClient;
+import api.buyhood.product.dto.response.RegisterProductRes;
+import api.buyhood.product.entity.Product;
+import api.buyhood.product.entity.ProductCategoryMapping;
+import api.buyhood.product.repository.ProductCategoryMappingRepository;
+import api.buyhood.product.repository.ProductRepository;
+import feign.FeignException;
+import jakarta.transaction.Transactional;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ProductService {
+
+	private final ProductRepository productRepository;
+	private final ProductCategoryMappingRepository productCategoryMappingRepository;
+	private final StoreFeignClient storeFeignClient;
+	private final ProductCategoryFeignClient productCategoryFeignClient;
+	private final UserFeignClient userFeignClient;
+
+	@Transactional
+	public RegisterProductRes registerProduct(
+		Long storeId,
+		String productName,
+		Long price,
+		Long stock,
+		List<Long> categoryIds,
+		String description
+	) {
+		StoreFeignDto getStoreDto = null;
+
+		try {
+			getStoreDto = storeFeignClient.getStoreOrElseThrow(storeId);
+		} catch (FeignException e) {
+			log.error("[FeignException]: 가게가 실제로 존재하지 않음. request: {}, contentUTF8: {}\n",
+				e.request(), e.contentUTF8(), e);
+			throw new NotFoundException(StoreErrorCode.STORE_NOT_FOUND);
+		}
+
+		List<Product> getProducts = productRepository.findActiveProductsByStoreId(getStoreDto.getStoreId());
+		checkForDuplicateInStore(productName, getProducts);
+
+		Product newProduct = Product.builder()
+			.name(productName)
+			.price(price)
+			.stock(stock)
+			.description(description)
+			.build();
+
+		productRepository.save(newProduct);
+
+		List<String> categoryNames = new ArrayList<>();
+		try {
+			for (Long categoryId : categoryIds) {
+				ProductCategoryFeignDto getProductCategoryDto =
+					productCategoryFeignClient.getCategoryOrElseThrow(categoryId);
+
+				categoryNames.add(getProductCategoryDto.getCategoryName());
+			}
+		} catch (FeignException e) {
+			log.error("[FeignException]: 상품에 적용하려는 상품 카테고리가 실제로 존재하지 않음. request: {}, contentUTF8: {}\n",
+				e.request(), e.contentUTF8(), e);
+			throw new NotFoundException(CategoryErrorCode.CATEGORY_NOT_FOUND);
+		}
+
+		List<ProductCategoryMapping> mappings = categoryIds.stream()
+			.map(categoryId ->
+				ProductCategoryMapping.builder()
+					.categoryId(categoryId)
+					.productId(newProduct.getId())
+					.build()
+			)
+			.toList();
+
+		productCategoryMappingRepository.saveAll(mappings);
+
+		return RegisterProductRes.of(newProduct, categoryNames);
+	}
+
+	@Transactional
+	public void patchProduct(
+		Long currentUserId,
+		Long storeId,
+		Long productId,
+		String productName,
+		Long price,
+		Long stock,
+		List<Long> categoryIds,
+		String description
+	) {
+		UserFeignDto getUserDto = fetchUser(currentUserId);
+		StoreFeignDto getStoreDto = fetchStore(storeId);
+
+		if (!getUserDto.getUserId().equals(getStoreDto.getStoreId())) {
+			throw new InvalidRequestException(StoreErrorCode.NOT_STORE_OWNER);
+		}
+
+		Product product = getProductOrElseThrow(productId);
+
+		if (StringUtils.hasText(productName) && !productName.equals(product.getName())) {
+			List<Product> getProducts = productRepository.findActiveProductsByStoreId(storeId);
+			checkForDuplicateInStore(productName, getProducts);
+			product.patchName(productName);
+		}
+
+		if (price != null) {
+			product.patchPrice(price);
+		}
+
+		if (stock != null) {
+			product.patchStock(stock);
+		}
+
+		if (StringUtils.hasText(description)) {
+			product.patchDescription(description);
+		}
+
+		if (categoryIds != null && !categoryIds.isEmpty()) {
+			// 요청으로 받은 카테고리 ID 값이 실제로 존재하는지 확인
+			categoryIds.forEach(this::validateCategoryExists);
+
+			// 매핑 테이블에 저장된 내용 삭제
+			productCategoryMappingRepository.deleteByProductId(productId);
+
+			// 새로운 카테고리 ID로 등록
+			List<ProductCategoryMapping> newMappings = categoryIds.stream()
+				.map(categoryId -> ProductCategoryMapping.builder()
+					.productId(productId)
+					.categoryId(categoryId)
+					.build())
+				.toList();
+
+			productCategoryMappingRepository.saveAll(newMappings);
+		}
+	}
+
+	@Transactional
+	public void addCategoriesToProduct(Long productId, List<Long> categoryIds) {
+		if (!productRepository.existsActiveProductById(productId)) {
+			throw new NotFoundException(ProductErrorCode.PRODUCT_NOT_FOUND);
+		}
+
+		for (Long categoryId : categoryIds) {
+			validateCategoryExists(categoryId);
+
+			boolean exists = productCategoryMappingRepository.existsByProductIdAndCategoryId(productId, categoryId);
+			if (!exists) {
+				ProductCategoryMapping mapping = ProductCategoryMapping.builder()
+					.productId(productId)
+					.categoryId(categoryId)
+					.build();
+				productCategoryMappingRepository.save(mapping);
+			}
+		}
+	}
+
+	@Transactional
+	public void removeCategoriesFromProduct(Long productId, List<Long> categoryIds) {
+		if (!productRepository.existsActiveProductById(productId)) {
+			throw new NotFoundException(ProductErrorCode.PRODUCT_NOT_FOUND);
+		}
+
+		for (Long categoryId : categoryIds) {
+			boolean exists = productCategoryMappingRepository.existsByProductIdAndCategoryId(productId, categoryId);
+			if (exists) {
+				productCategoryMappingRepository.deleteByProductIdAndCategoryId(productId, categoryId);
+			}
+		}
+	}
+
+
+	private Product getProductOrElseThrow(Long productId) {
+		return productRepository.findActiveProductByProductId(productId)
+			.orElseThrow(() -> new NotFoundException(ProductErrorCode.PRODUCT_NOT_FOUND));
+	}
+
+	private void checkForDuplicateInStore(String productName, List<Product> products) {
+		for (Product product : products) {
+			if (product.getName().equalsIgnoreCase(productName)) {
+				throw new ConflictException(ProductErrorCode.DUPLICATE_PRODUCT_NAME);
+			}
+		}
+	}
+
+	private UserFeignDto fetchUser(Long userId) {
+		try {
+			return userFeignClient.getRoleSellerOrElseThrow(userId);
+		} catch (FeignException e) {
+			if (e.status() == 404) {
+				throw new NotFoundException(UserErrorCode.USER_NOT_FOUND);
+			}
+			throw new ServerException(CommonErrorCode.NOT_DEFINED_FEIGN_EXCEPTION);
+		}
+	}
+
+	private StoreFeignDto fetchStore(Long storeId) {
+		try {
+			return storeFeignClient.getStoreOrElseThrow(storeId);
+		} catch (FeignException e) {
+			if (e.status() == 404) {
+				throw new NotFoundException(StoreErrorCode.STORE_NOT_FOUND);
+			}
+			throw new ServerException(CommonErrorCode.NOT_DEFINED_FEIGN_EXCEPTION);
+		}
+	}
+
+	private void validateCategoryExists(Long categoryId) {
+		try {
+			productCategoryFeignClient.getCategoryOrElseThrow(categoryId);
+		} catch (FeignException e) {
+			if (e.status() == 404) {
+				throw new NotFoundException(CategoryErrorCode.CATEGORY_NOT_FOUND);
+			}
+			throw new ServerException(CommonErrorCode.NOT_DEFINED_FEIGN_EXCEPTION);
+		}
+	}
+}

--- a/buyhood-store/src/main/java/api/buyhood/store/controller/InternalStoreController.java
+++ b/buyhood-store/src/main/java/api/buyhood/store/controller/InternalStoreController.java
@@ -1,0 +1,27 @@
+package api.buyhood.store.controller;
+
+import api.buyhood.dto.store.StoreFeignDto;
+import api.buyhood.store.service.InternalStoreService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/internal")
+public class InternalStoreController {
+
+	private final InternalStoreService internalStoreService;
+
+	@GetMapping("/v1/stores/{id}")
+	public StoreFeignDto getStoreOrElseThrow(@PathVariable("id") Long storeId) {
+		return internalStoreService.getStoreOrElseThrow(storeId);
+	}
+
+	@GetMapping("/v1/stores/{id}/exists")
+	public Boolean existsById(@PathVariable("id") Long storeId) {
+		return internalStoreService.existsById(storeId);
+	}
+}

--- a/buyhood-store/src/main/java/api/buyhood/store/repository/InternalStoreRepository.java
+++ b/buyhood-store/src/main/java/api/buyhood/store/repository/InternalStoreRepository.java
@@ -1,0 +1,15 @@
+package api.buyhood.store.repository;
+
+import api.buyhood.store.entity.Store;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+public interface InternalStoreRepository extends JpaRepository<Store, Long> {
+
+	@Query("select s from Store s where s.id = :storeId and s.deletedAt is null")
+	Optional<Store> findActiveStoreById(Long storeId);
+
+	@Query("select count(s) > 0 from Store s where s.id = :storeId and s.deletedAt is null")
+	Boolean existsActiveStoreById(Long storeId);
+}

--- a/buyhood-store/src/main/java/api/buyhood/store/service/InternalStoreService.java
+++ b/buyhood-store/src/main/java/api/buyhood/store/service/InternalStoreService.java
@@ -1,0 +1,30 @@
+package api.buyhood.store.service;
+
+import api.buyhood.dto.store.StoreFeignDto;
+import api.buyhood.errorcode.SellerErrorCode;
+import api.buyhood.exception.NotFoundException;
+import api.buyhood.store.entity.Store;
+import api.buyhood.store.repository.InternalStoreRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class InternalStoreService {
+
+	private final InternalStoreRepository internalStoreRepository;
+
+	@Transactional(readOnly = true)
+	public StoreFeignDto getStoreOrElseThrow(Long storeId) {
+		Store getStore = internalStoreRepository.findActiveStoreById(storeId)
+			.orElseThrow(() -> new NotFoundException(SellerErrorCode.SELLER_NOT_FOUND));
+
+		return new StoreFeignDto(getStore.getId(), getStore.getName(), getStore.getSellerId());
+	}
+
+	@Transactional(readOnly = true)
+	public Boolean existsById(Long storeId) {
+		return internalStoreRepository.existsActiveStoreById(storeId);
+	}
+}

--- a/buyhood-store/src/main/java/api/buyhood/store/service/StoreService.java
+++ b/buyhood-store/src/main/java/api/buyhood/store/service/StoreService.java
@@ -137,7 +137,7 @@ public class StoreService {
 	public GetStoreRes getActiveStore(Long storeId) {
 		Store getStore = getActiveStoreOrElseThrow(storeId);
 
-		UserFeignDto getSellerRes = userFeignClient.getSellerResOrElseThrow(getStore.getSellerId());
+		UserFeignDto getSellerRes = userFeignClient.getRoleSellerOrElseThrow(getStore.getSellerId());
 
 		StoreCategoryFeignDto getStoreCategoryRes =
 			storeCategoryFeignClient.getStoreCategoryResByIdOrElseThrow(getStore.getStoreCategoryId());

--- a/buyhood-user/src/main/java/api/buyhood/domain/user/controller/InternalUserController.java
+++ b/buyhood-user/src/main/java/api/buyhood/domain/user/controller/InternalUserController.java
@@ -17,12 +17,12 @@ public class InternalUserController {
 
 	@GetMapping("/v1/users/{id}")
 	public UserFeignDto getUserInternal(@PathVariable Long id) {
-		return internalUserService.getUserInternal(id);
+		return internalUserService.getRoleUserOrElseThrow(id);
 	}
 
 	@GetMapping("/v1/sellers/{id}")
 	public UserFeignDto getSellerInternal(@PathVariable Long id) {
-		return internalUserService.getSellerInternal(id);
+		return internalUserService.getRoleSellerOrElseThrow(id);
 	}
 
 	@GetMapping("/v1/users/{id}/exists")

--- a/buyhood-user/src/main/java/api/buyhood/domain/user/service/InternalUserService.java
+++ b/buyhood-user/src/main/java/api/buyhood/domain/user/service/InternalUserService.java
@@ -18,7 +18,7 @@ public class InternalUserService {
 	private final InternalUserRepository internalUserRepository;
 
 	@Transactional(readOnly = true)
-	public UserFeignDto getUserInternal(Long userId) {
+	public UserFeignDto getRoleUserOrElseThrow(Long userId) {
 		User getUser = internalUserRepository.findActiveUserById(userId)
 			.orElseThrow(() -> new NotFoundException(UserErrorCode.USER_NOT_FOUND));
 
@@ -31,7 +31,7 @@ public class InternalUserService {
 	}
 
 	@Transactional(readOnly = true)
-	public UserFeignDto getSellerInternal(Long userId) {
+	public UserFeignDto getRoleSellerOrElseThrow(Long userId) {
 		User getUser = internalUserRepository.findActiveUserById(userId)
 			.orElseThrow(() -> new NotFoundException(UserErrorCode.USER_NOT_FOUND));
 


### PR DESCRIPTION
## 📌 PR 요약

- 상품 도메인 모듈 분리

## 🔗 관련 이슈

- MFLP-79

## 🛠️ 작업 내역

- 상품 등록
- 상품 수정
- 상품에 적용된 카테고리 추가 
- 상품에 적용된 카테고리 삭제
- 필요한 FeignClient 정의

## 📸 스크린샷 (선택)

작업 결과를 스크린샷으로 첨부해주세요.

| 기능  | 스크린샷               |
|-----|--------------------|
| PNG | ![스크린샷](사진을 넣어주세요) |

## ⚠️ 주의 사항 (선택)

- 서비스 로직 위주로 최대한 구현했습니다.
- 카테고리의 경우 가게, 상품 모두 물리적 삭제
- 상품과 가게는 논리적 삭제입니다.
   - 상품과 상품 카테고리 간의 매핑 테이블의 경우 물리적 삭제로 우선 구현했습니다
- 테스트는 따로 진행하지 못했습니다.
- develop에서 새로운 브랜치를 만들려고 했으나 빌드 스크립트 파일 등이 나오지 않아서 부득이하게 `feat/MFLP-80` 브랜치에서 새로 생성했습니다.

## ✅ 체크리스트

PR 작성자가 확인해야 할 항목입니다:

- [ ] 코드가 정상적으로 동작하는지 확인했습니다.
- [x] 코드 리뷰어를 등록했습니다.
- [x] Labels를 등록했습니다.